### PR TITLE
[FEAT] 구인글 수정 API

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -91,6 +91,6 @@ public interface RecruitmentPostApi {
     )
     @Operation(summary = "구인글 수정 API")
     ResponseEntity<Void> modifyRecruitmentPost(@Valid @RequestBody CreateRecruitmentPostRequestDto requestDto,
-                                               @AuthUser User user);
+                                               @Valid @PathVariable("id") Long postId, @AuthUser User user);
 
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -153,7 +153,23 @@ public class RecruitmentPostController implements RecruitmentPostApi {
 
     @PutMapping("/{id}")
     @Override
-    public ResponseEntity<Void> modifyRecruitmentPost(CreateRecruitmentPostRequestDto requestDto, @AuthUser User user) {
+    public ResponseEntity<Void> modifyRecruitmentPost(@Valid @RequestBody CreateRecruitmentPostRequestDto requestDto,
+                                                      @Valid @PathVariable("id") Long postId, @AuthUser User user) {
+
+        Field field = fieldService.findById(DEVELOP_ID);
+
+        RecruitmentPost srcRecruitmentPost = recruitmentPostMapper.toRecruitmentEntity(requestDto, field);
+        RecruitmentPost dstRecruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
+
+        List<RecruitmentRoleSkill> recruitmentRoleSkills = new ArrayList<>();
+        List<RecruitmentRole> recruitmentRoles = getRecruitmentRoles(requestDto, dstRecruitmentPost,
+                recruitmentRoleSkills);
+
+        List<RecruitmentTag> recruitmentTags = getRecruitmentTags(requestDto, dstRecruitmentPost);
+
+        recruitmentPostFacade.modifyRecruitmentPost(dstRecruitmentPost, srcRecruitmentPost, recruitmentRoles,
+                recruitmentRoleSkills,
+                recruitmentTags);
 
         return ResponseEntity.ok().build();
     }
@@ -190,7 +206,7 @@ public class RecruitmentPostController implements RecruitmentPostApi {
                     tagEntity);
             recruitmentTags.add(recruitmentTagEntity);
             recruitmentTags.add(recruitmentPostMapper.toRecruitmentTagEntity(recruitmentPost,
-                    recruitmentPostMapper.toTagEntity(requestDto.courseTag().courseTagName(), TagType.PROFESSOR)));
+                    recruitmentPostMapper.toTagEntity(requestDto.courseTag().courseProfessor(), TagType.PROFESSOR)));
         }
         return recruitmentTags;
     }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -168,8 +168,7 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         List<RecruitmentTag> recruitmentTags = getRecruitmentTags(requestDto, dstRecruitmentPost);
 
         recruitmentPostFacade.modifyRecruitmentPost(dstRecruitmentPost, srcRecruitmentPost, recruitmentRoles,
-                recruitmentRoleSkills,
-                recruitmentTags);
+                recruitmentRoleSkills, recruitmentTags);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/entity/RecruitmentPost.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/entity/RecruitmentPost.java
@@ -152,4 +152,29 @@ public class RecruitmentPost extends BaseEntity {
         this.isClosed = true;
         return this;
     }
+
+    public void updateRecruitmentPost(String title, String content, Scope scope, Category category,
+                                      Field field,
+                                      ProceedType proceedType, LocalDate proceedingStart,
+                                      LocalDate proceedingEnd,
+                                      LocalDate deadline,
+                                      long bookmarkCount, String kakaoLink, boolean isClosed,
+                                      Meeteam meeteam, long applicantCount,
+                                      long responseCount) {
+        this.title = title;
+        this.content = content;
+        this.scope = scope;
+        this.category = category;
+        this.field = field;
+        this.proceedType = proceedType;
+        this.proceedingStart = proceedingStart;
+        this.proceedingEnd = proceedingEnd;
+        this.deadline = deadline;
+        this.bookmarkCount = bookmarkCount;
+        this.kakaoLink = kakaoLink;
+        this.isClosed = isClosed;
+        this.meeteam = meeteam;
+        this.applicantCount = applicantCount;
+        this.responseCount = responseCount;
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/facade/RecruitmentPostFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/facade/RecruitmentPostFacade.java
@@ -30,16 +30,27 @@ public class RecruitmentPostFacade {
     public Long createRecruitmentPost(RecruitmentPost recruitmentPost, List<RecruitmentRole> recruitmentRoles,
                                       List<RecruitmentRoleSkill> recruitmentRoleSkills,
                                       List<RecruitmentTag> recruitmentTags) {
-
         RecruitmentPost newRecruitmentPost = recruitmentPostService.writeRecruitmentPost(recruitmentPost);
-
-        recruitmentRoles.forEach(recruitmentRoleService::createRecruitmentRole);
-
-        recruitmentRoleSkills.forEach(recruitmentRoleSkillService::createRecruitmentRoleSkill);
-
-        recruitmentTags.forEach(recruitmentTagService::createRecruitmentTag);
+        recruitmentRoleService.createRecruitmentRoles(recruitmentRoles);
+        recruitmentRoleSkillService.createRecruitmentRoleSkills(recruitmentRoleSkills);
+        recruitmentTagService.createRecruitmentTags(recruitmentTags);
 
         return newRecruitmentPost.getId();
+    }
+
+    @Transactional
+    public void modifyRecruitmentPost(RecruitmentPost dstRecruitmentPost, RecruitmentPost srcRecruitmentPost,
+                                      List<RecruitmentRole> recruitmentRoles,
+                                      List<RecruitmentRoleSkill> recruitmentRoleSkills,
+                                      List<RecruitmentTag> recruitmentTags) {
+
+        recruitmentPostService.modifyRecruitmentPost(dstRecruitmentPost, srcRecruitmentPost);
+
+        // cascade 설정을 하여 recruitmentRoleService에서 Role과 Skills를 한 번에 삭제한다.
+        recruitmentRoleService.modifyRecruitmentRoleAndSkills(recruitmentRoles, recruitmentRoleSkills,
+                dstRecruitmentPost.getId());
+
+        recruitmentTagService.modifyRecruitmentTag(recruitmentTags, dstRecruitmentPost.getId());
     }
 
     @Transactional
@@ -50,5 +61,4 @@ public class RecruitmentPostFacade {
 
         recruitmentRoleService.addApplicantCount(recruitmentRole);
     }
-
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
@@ -35,4 +35,19 @@ public class RecruitmentPostService {
         return recruitmentPost;
 
     }
+
+    @Transactional
+    public RecruitmentPost modifyRecruitmentPost(RecruitmentPost dstRecruitmentPost,
+                                                 RecruitmentPost srcRecruitmentPost) {
+
+        dstRecruitmentPost.updateRecruitmentPost(srcRecruitmentPost.getTitle(), srcRecruitmentPost.getContent(),
+                srcRecruitmentPost.getScope(), srcRecruitmentPost.getCategory(), srcRecruitmentPost.getField(),
+                srcRecruitmentPost.getProceedType(), srcRecruitmentPost.getProceedingStart(),
+                srcRecruitmentPost.getProceedingEnd(), srcRecruitmentPost.getDeadline(),
+                srcRecruitmentPost.getBookmarkCount(),
+                srcRecruitmentPost.getKakaoLink(), srcRecruitmentPost.isClosed(), srcRecruitmentPost.getMeeteam(),
+                srcRecruitmentPost.getApplicantCount(), srcRecruitmentPost.getResponseCount());
+
+        return recruitmentPostRepository.save(dstRecruitmentPost);
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/entity/RecruitmentRole.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/entity/RecruitmentRole.java
@@ -33,7 +33,7 @@ public class RecruitmentRole {
     private Long id;
 
     @ManyToOne(fetch = LAZY, optional = false)
-    @JoinColumn(name = "recruitment_id")
+    @JoinColumn(name = "recruitment_post_id")
     private RecruitmentPost recruitmentPost;
 
     @ManyToOne(fetch = LAZY, optional = false)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
@@ -22,4 +22,6 @@ public interface RecruitmentRoleRepository extends JpaRepository<RecruitmentRole
         return findByIdWithRecruitmentRoleAndRole(recruitmentRoleId).orElseThrow(
                 () -> new RecruitmentRoleException(INVALID_RECRUITMENT_ROLE_ID));
     }
+
+    void deleteAllByRecruitmentPostId(Long postId);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
@@ -7,15 +7,18 @@ import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_role.dto.AvailableRecruitmentRoleDto;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
 import synk.meeteam.domain.recruitment.recruitment_role.repository.RecruitmentRoleRepository;
+import synk.meeteam.domain.recruitment.recruitment_role_skill.entity.RecruitmentRoleSkill;
+import synk.meeteam.domain.recruitment.recruitment_role_skill.repository.RecruitmentRoleSkillRepository;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitmentRoleService {
     private final RecruitmentRoleRepository recruitmentRoleRepository;
+    private final RecruitmentRoleSkillRepository recruitmentRoleSkillRepository;
 
     @Transactional
-    public RecruitmentRole createRecruitmentRole(RecruitmentRole recruitmentRole) {
-        return recruitmentRoleRepository.save(recruitmentRole);
+    public List<RecruitmentRole> createRecruitmentRoles(List<RecruitmentRole> recruitmentRoles) {
+        return recruitmentRoleRepository.saveAll(recruitmentRoles);
     }
 
     public List<RecruitmentRole> findByRecruitmentPostId(Long recruitmentPostId) {
@@ -36,5 +39,14 @@ public class RecruitmentRoleService {
     public List<AvailableRecruitmentRoleDto> findAvailableRecruitmentRole(Long postId) {
         return recruitmentRoleRepository.findAvailableRecruitmentRoleByRecruitmentId(
                 postId);
+    }
+
+    @Transactional
+    public void modifyRecruitmentRoleAndSkills(List<RecruitmentRole> recruitmentRoles,
+                                               List<RecruitmentRoleSkill> recruitmentRoleSkills, Long postId) {
+        recruitmentRoleRepository.deleteAllByRecruitmentPostId(postId);
+
+        recruitmentRoleRepository.saveAll(recruitmentRoles);
+        recruitmentRoleSkillRepository.saveAll(recruitmentRoleSkills);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/entity/RecruitmentRoleSkill.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/entity/RecruitmentRoleSkill.java
@@ -16,6 +16,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import synk.meeteam.domain.common.skill.entity.Skill;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
 
@@ -37,6 +39,7 @@ public class RecruitmentRoleSkill {
 
     @ManyToOne(fetch = LAZY, optional = false)
     @JoinColumn(name = "recruitment_role_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private RecruitmentRole recruitmentRole;
 
     @ManyToOne(fetch = LAZY, optional = false)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/repository/RecruitmentRoleSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/repository/RecruitmentRoleSkillRepository.java
@@ -1,8 +1,17 @@
 package synk.meeteam.domain.recruitment.recruitment_role_skill.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_role_skill.entity.RecruitmentRoleSkill;
 
 public interface RecruitmentRoleSkillRepository extends JpaRepository<RecruitmentRoleSkill, Long> {
 
+    @Transactional
+    @Modifying
+    @Query("delete from RecruitmentRoleSkill r where r.recruitmentRole.id in :recruitmentRoleIds")
+    void deleteAllByRecruitmentRoleIdInQuery(@Param("recruitmentRoleIds") List<Long> recruitmentRoleIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/service/RecruitmentRoleSkillService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/service/RecruitmentRoleSkillService.java
@@ -1,5 +1,6 @@
 package synk.meeteam.domain.recruitment.recruitment_role_skill.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +13,7 @@ public class RecruitmentRoleSkillService {
     private final RecruitmentRoleSkillRepository recruitmentRoleSkillRepository;
 
     @Transactional
-    public RecruitmentRoleSkill createRecruitmentRoleSkill(RecruitmentRoleSkill recruitmentRoleSkill) {
-        return recruitmentRoleSkillRepository.save(recruitmentRoleSkill);
+    public List<RecruitmentRoleSkill> createRecruitmentRoleSkills(List<RecruitmentRoleSkill> recruitmentRoleSkills) {
+        return recruitmentRoleSkillRepository.saveAll(recruitmentRoleSkills);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
@@ -9,4 +9,6 @@ import synk.meeteam.domain.recruitment.recruitment_tag.entity.RecruitmentTag;
 public interface RecruitmentTagRepository extends JpaRepository<RecruitmentTag, Long> {
     @Query("SELECT r FROM RecruitmentTag r JOIN FETCH r.tag JOIN FETCH r.recruitmentPost WHERE r.recruitmentPost.id = :postId")
     List<RecruitmentTag> findByPostIdWithTag(@Param("postId") Long postId);
+
+    void deleteAllByRecruitmentPostId(Long postId);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/service/RecruitmentTagService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/service/RecruitmentTagService.java
@@ -25,6 +25,12 @@ public class RecruitmentTagService {
     private final TagRepository tagRepository;
 
     @Transactional
+    public List<RecruitmentTag> createRecruitmentTags(List<RecruitmentTag> recruitmentTags) {
+        return recruitmentTags.stream().map(recruitmentTag -> createRecruitmentTag(recruitmentTag))
+                .toList();
+    }
+
+    @Transactional
     public RecruitmentTag createRecruitmentTag(RecruitmentTag recruitmentTag) {
         Tag foundTag = tagRepository.findByName(recruitmentTag.getTag().getName()).orElse(null);
         if (foundTag == null) {
@@ -62,4 +68,9 @@ public class RecruitmentTagService {
         return RecruitmentTagVO.from(recruitmentTags, courseName, courseProfessor);
     }
 
+    @Transactional
+    public void modifyRecruitmentTag(List<RecruitmentTag> recruitmentTags, Long postId) {
+        recruitmentTagRepository.deleteAllByRecruitmentPostId(postId);
+        createRecruitmentTags(recruitmentTags);
+    }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostEntityTest.java
@@ -1,10 +1,15 @@
 package synk.meeteam.domain.recruitment.recruitment_post;
 
 
+import java.time.LocalDate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.exception.RecruitmentPostException;
+import synk.meeteam.global.entity.Category;
+import synk.meeteam.global.entity.ProceedType;
+import synk.meeteam.global.entity.Scope;
 
 public class RecruitmentPostEntityTest {
 
@@ -30,6 +35,24 @@ public class RecruitmentPostEntityTest {
         Assertions.assertThatThrownBy(
                         () -> recruitmentPost.closeRecruitmentPost(requestUserId))
                 .isInstanceOf(RecruitmentPostException.class);
+    }
+
+    @Test
+    void 구인글수정_성공() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상제목");
+        Long requestUserId = 1L;
+        recruitmentPost.setCreatedBy(requestUserId);
+
+        // when
+        recruitmentPost.updateRecruitmentPost("정상제목2", "내용", Scope.ON_CAMPUS, Category.PROJECT, new Field(1L, "개발"),
+                ProceedType.ON_LINE, LocalDate.of(2024, 1, 5), LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 15), 5L,
+                "kakaolink~~", false, null, 5L, 5L);
+
+        // then
+        Assertions.assertThat(recruitmentPost)
+                .extracting("title", "content", "scope", "category")
+                .containsExactly("정상제목2", "내용", Scope.ON_CAMPUS, Category.PROJECT);
     }
 
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostServiceTest.java
@@ -101,4 +101,20 @@ public class RecruitmentPostServiceTest {
                         () -> recruitmentPostService.closeRecruitment(postId, userId))
                 .isInstanceOf(RecruitmentPostException.class);
     }
+
+    @Test
+    void 구인글수정_성공() {
+        // given
+        RecruitmentPost srcRecruitmentPost = RecruitmentPostFixture.createRecruitmentPost("수정하려는제목입니다");
+        RecruitmentPost dstRecruitmentPost = RecruitmentPostFixture.createRecruitmentPost("그냥제목입니다");
+
+        doReturn(dstRecruitmentPost).when(recruitmentPostRepository).save(any());
+
+        // when
+        RecruitmentPost newRecruitmentPost = recruitmentPostService.modifyRecruitmentPost(dstRecruitmentPost,
+                srcRecruitmentPost);
+
+        // then
+        Assertions.assertThat(newRecruitmentPost.getTitle()).isEqualTo("수정하려는제목입니다");
+    }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostTest.java
@@ -230,6 +230,25 @@ public class RecruitmentPostTest {
         assertEquals(INVALID_RECRUITMENT_ROLE_ID.name(), twiceResponseEntity.getBody().getName());
     }
 
+    @Test
+    void 구인글수정_성공() {
+        Long postId = 1L;
+        CreateRecruitmentPostRequestDto requestDto = createRequestDto_title("수정된 제목입니다.");
+        HttpEntity<CreateRecruitmentPostRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
+
+        restTemplate.put(RECRUITMENT_URL + "/1", requestEntity);
+
+        HttpEntity<CreateRecruitmentPostRequestDto> checkRequestEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<GetRecruitmentPostResponseDto> responseEntity = restTemplate.exchange(RECRUITMENT_URL + "/1",
+                HttpMethod.GET, checkRequestEntity, GetRecruitmentPostResponseDto.class);
+
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        GetRecruitmentPostResponseDto body = responseEntity.getBody();
+        assertEquals(body.title(), "수정된 제목입니다.");
+    }
+
     ///////// Dto 생성 로직 /////////
 
     private CreateRecruitmentPostRequestDto createRequestDto() {

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleServiceTest.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.recruitment.recruitment_role;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture.TITLE;
 
@@ -37,13 +38,15 @@ public class RecruitmentRoleServiceTest {
         Role role = RoleFixture.createRole("백엔드개발자");
         RecruitmentRole recruitmentRole = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost,
                 role, 2L);
-        doReturn(recruitmentRole).when(recruitmentRoleRepository).save(recruitmentRole);
+        List<RecruitmentRole> recruitmentRoles = new ArrayList<>();
+        recruitmentRoles.add(recruitmentRole);
+        doReturn(recruitmentRoles).when(recruitmentRoleRepository).saveAll(any());
 
         // when
-        RecruitmentRole savedRecruitmentRole = recruitmentRoleService.createRecruitmentRole(recruitmentRole);
+        List<RecruitmentRole> savedRecruitmentRoles = recruitmentRoleService.createRecruitmentRoles(recruitmentRoles);
 
         // then
-        Assertions.assertThat(savedRecruitmentRole)
+        Assertions.assertThat(savedRecruitmentRoles.get(0))
                 .extracting("recruitmentPost", "role", "count")
                 .containsExactly(recruitmentPost, role, 2L);
     }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillRepositoryTest.java
@@ -1,5 +1,6 @@
 package synk.meeteam.domain.recruitment.recruitment_role_skill;
 
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,5 +75,18 @@ public class RecruitmentRoleSkillRepositoryTest {
             recruitmentRoleSkillRepository.saveAndFlush(recruitmentRoleSkill);
         }).isInstanceOf(DataIntegrityViolationException.class);
 
+    }
+
+    @Test
+    void 구인역할삭제_성공() {
+        // given
+        List<Long> deleteRecruitmentRoleIds = List.of(1L, 2L);
+
+        // when
+        recruitmentRoleSkillRepository.deleteAllByRecruitmentRoleIdInQuery(deleteRecruitmentRoleIds);
+
+        // then
+        List<RecruitmentRoleSkill> found = recruitmentRoleSkillRepository.findAllById(List.of(1L, 2L, 3L, 4L, 5L));
+        Assertions.assertThat(found.size()).isEqualTo(0);
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillServiceTest.java
@@ -3,7 +3,10 @@ package synk.meeteam.domain.recruitment.recruitment_role_skill;
 import static org.mockito.Mockito.doReturn;
 import static synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture.TITLE;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,25 +32,81 @@ public class RecruitmentRoleSkillServiceTest {
     @Mock
     private RecruitmentRoleSkillRepository recruitmentRoleSkillRepository;
 
+    private List<RecruitmentRoleSkill> recruitmentRoleSkills;
+
+    private RecruitmentRoleSkill recruitmentRoleSkill_1;
+
+    private RecruitmentRoleSkill recruitmentRoleSkill_2;
+
+    @BeforeEach
+    void init() {
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost(TITLE);
+        Role role_1 = RoleFixture.createRole("백엔드개발자");
+        Skill skill_1 = SkillFixture.crateSkill("spring");
+        RecruitmentRole recruitmentRole_1 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_1,
+                3L);
+        Role role_2 = RoleFixture.createRole("프론트엔드개발자");
+        Skill skill_2 = SkillFixture.crateSkill("자바스크립트");
+        RecruitmentRole recruitmentRole_2 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_2,
+                3L);
+        recruitmentRoleSkill_1 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
+                recruitmentRole_1, skill_1);
+        recruitmentRoleSkill_2 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
+                recruitmentRole_2, skill_2);
+        recruitmentRoleSkills = new ArrayList<>();
+        recruitmentRoleSkills.add(recruitmentRoleSkill_1);
+        recruitmentRoleSkills.add(recruitmentRoleSkill_2);
+    }
+
     @Test
     void 구인역할스킬저장_구인역할스킬저장성공_정상입력경우() {
         // given
-        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost(TITLE);
-        Role role = RoleFixture.createRole("백엔드개발자");
-        RecruitmentRole recruitmentRole = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role,
-                3L);
-        Skill skill = SkillFixture.crateSkill("spring");
-        RecruitmentRoleSkill recruitmentRoleSkill = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
-                recruitmentRole, skill);
-        doReturn(recruitmentRoleSkill).when(recruitmentRoleSkillRepository).save(recruitmentRoleSkill);
+        doReturn(recruitmentRoleSkills).when(recruitmentRoleSkillRepository).saveAll(recruitmentRoleSkills);
 
         // when
-        RecruitmentRoleSkill savedRecruitmentRoleSkill = recruitmentRoleSkillService.createRecruitmentRoleSkill(
-                recruitmentRoleSkill);
+        List<RecruitmentRoleSkill> savedRecruitmentRoleSkills = recruitmentRoleSkillService.createRecruitmentRoleSkills(
+                recruitmentRoleSkills);
 
         // then
-        Assertions.assertThat(savedRecruitmentRoleSkill)
+        Assertions.assertThat(savedRecruitmentRoleSkills.get(0))
                 .extracting("recruitmentRole", "skill")
-                .containsExactly(recruitmentRoleSkill.getRecruitmentRole(), recruitmentRoleSkill.getSkill());
+                .containsExactly(recruitmentRoleSkill_1.getRecruitmentRole(), recruitmentRoleSkill_1.getSkill());
     }
+
+//    @Test
+//    void 구인역할수정_성공(){
+//        // given
+//        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost(TITLE);
+//        Role role_1 = RoleFixture.createRole("시스템개발자");
+//        Skill skill_1 = SkillFixture.crateSkill("C");
+//        RecruitmentRole recruitmentRole_1 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_1,
+//                3L);
+//        Role role_2 = RoleFixture.createRole("기획자");
+//        Skill skill_2 = SkillFixture.crateSkill("figma");
+//        RecruitmentRole recruitmentRole_2 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_2,
+//                3L);
+//        RecruitmentRoleSkill tmp_recruitmentRoleSkill_1 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
+//                recruitmentRole_1, skill_1);
+//        RecruitmentRoleSkill tmp_recruitmentRoleSkill_2 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
+//                recruitmentRole_2, skill_2);
+//        List<RecruitmentRoleSkill> tmp_recruitmentRoleSkills = new ArrayList<>();
+//        tmp_recruitmentRoleSkills.add(tmp_recruitmentRoleSkill_1);
+//        tmp_recruitmentRoleSkills.add(tmp_recruitmentRoleSkill_2);
+//
+//        doNothing().when(recruitmentRoleSkillRepository).deleteAllByRecruitmentRoleIdInQuery(anyList());
+//        doReturn(tmp_recruitmentRoleSkills).when(recruitmentRoleSkillRepository).saveAll(anyList());
+//
+//        // when
+//        List<RecruitmentRoleSkill> newRecruitmentRoleSkills = recruitmentRoleSkillService.modifyRecruitmentRoleSkills(
+//                anyList());
+//
+//        // then
+//        Assertions.assertThat(newRecruitmentRoleSkills.size()).isEqualTo(2);
+//
+//        Assertions.assertThat(newRecruitmentRoleSkills.get(0).getRecruitmentRole().getRole().getName()).isEqualTo("시스템개발자");
+//        Assertions.assertThat(newRecruitmentRoleSkills.get(0).getSkill().getName()).isEqualTo("C");
+//        Assertions.assertThat(newRecruitmentRoleSkills.get(1).getRecruitmentRole().getRole().getName()).isEqualTo("기획자");
+//        Assertions.assertThat(newRecruitmentRoleSkills.get(1).getSkill().getName()).isEqualTo("figma");
+//
+//    }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role_skill/RecruitmentRoleSkillServiceTest.java
@@ -72,41 +72,4 @@ public class RecruitmentRoleSkillServiceTest {
                 .extracting("recruitmentRole", "skill")
                 .containsExactly(recruitmentRoleSkill_1.getRecruitmentRole(), recruitmentRoleSkill_1.getSkill());
     }
-
-//    @Test
-//    void 구인역할수정_성공(){
-//        // given
-//        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost(TITLE);
-//        Role role_1 = RoleFixture.createRole("시스템개발자");
-//        Skill skill_1 = SkillFixture.crateSkill("C");
-//        RecruitmentRole recruitmentRole_1 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_1,
-//                3L);
-//        Role role_2 = RoleFixture.createRole("기획자");
-//        Skill skill_2 = SkillFixture.crateSkill("figma");
-//        RecruitmentRole recruitmentRole_2 = RecruitmentRoleFixture.createRecruitmentRoleFixture(recruitmentPost, role_2,
-//                3L);
-//        RecruitmentRoleSkill tmp_recruitmentRoleSkill_1 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
-//                recruitmentRole_1, skill_1);
-//        RecruitmentRoleSkill tmp_recruitmentRoleSkill_2 = RecruitmentRoleSkillFixture.createRecruitmentRoleSkill(
-//                recruitmentRole_2, skill_2);
-//        List<RecruitmentRoleSkill> tmp_recruitmentRoleSkills = new ArrayList<>();
-//        tmp_recruitmentRoleSkills.add(tmp_recruitmentRoleSkill_1);
-//        tmp_recruitmentRoleSkills.add(tmp_recruitmentRoleSkill_2);
-//
-//        doNothing().when(recruitmentRoleSkillRepository).deleteAllByRecruitmentRoleIdInQuery(anyList());
-//        doReturn(tmp_recruitmentRoleSkills).when(recruitmentRoleSkillRepository).saveAll(anyList());
-//
-//        // when
-//        List<RecruitmentRoleSkill> newRecruitmentRoleSkills = recruitmentRoleSkillService.modifyRecruitmentRoleSkills(
-//                anyList());
-//
-//        // then
-//        Assertions.assertThat(newRecruitmentRoleSkills.size()).isEqualTo(2);
-//
-//        Assertions.assertThat(newRecruitmentRoleSkills.get(0).getRecruitmentRole().getRole().getName()).isEqualTo("시스템개발자");
-//        Assertions.assertThat(newRecruitmentRoleSkills.get(0).getSkill().getName()).isEqualTo("C");
-//        Assertions.assertThat(newRecruitmentRoleSkills.get(1).getRecruitmentRole().getRole().getName()).isEqualTo("기획자");
-//        Assertions.assertThat(newRecruitmentRoleSkills.get(1).getSkill().getName()).isEqualTo("figma");
-//
-//    }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #111 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 구인글 수정을 구현했습니다.
- 일부 자잘한 테스트는 생략했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
### 이전 상태
<img width="460" alt="스크린샷 2024-03-26 오후 3 06 42" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/89b2b40e-2002-4f9f-ace4-2e48dcfa3da1">
<img width="338" alt="스크린샷 2024-03-26 오후 3 06 50" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/ce39377e-877f-4950-bd9d-aabeeeacad3a">
<img width="304" alt="스크린샷 2024-03-26 오후 4 03 55" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/f8c3641c-d456-4ba4-bb4f-0f96561e76c8">


### 수정 후 상태
<img width="442" alt="스크린샷 2024-03-26 오후 3 07 56" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/b236588f-9e28-4095-93a7-e34f70308091">
<img width="291" alt="스크린샷 2024-03-26 오후 3 08 06" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/33345077-68fb-40c1-87a0-78f3b435f533">
<img width="253" alt="스크린샷 2024-03-26 오후 3 14 56" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/48fc6ab6-212a-423e-b8e5-4031ac222ce0">

### 요청바디
```
{
  "scope": "교내",
  "category": "프로젝트",
  "deadline": "2023-02-05",
  "proceedingStart": "2023-02-01",
  "proceedingEnd": "2023-05-01",
  "fieldId": 1,
  "proceedType": "온라인",
  "courseTag": {
    "isCourse": true,
    "courseTagName": "응용소프트웨어실습",
    "courseProfessor": "김용혁"
  },
  "tags": ["newSpring","newJava","newJPA"],
  "recruitmentRoles": [
    {
      "roleId": 1,
      "count": 3,
      "skillIds": [4, 5, 6]
    }
  ],
  "title": "졸작 사람 구합니다22",
  "content": "안녕하세요. 사람구하는데 진짜 고수만 구해요.."
}
```

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 하나의 트랜잭션으로 묶기 위해서 파사드 패턴을 사용했습니다!

### 중요 포인트 1
- 특이점으로, `recruitmentRole` 과 `recruitmentRoleSkill` 에 대한 수정을 `recruitmentRoleService`에서 진행했습니다!
- 이 부분에 대해서 고민이 좀 많았는데요. 두 객체가 너무 연관이 깊게 되어 있어서 여러 방법에 대해 고민했었습니다.

1. 각각의 서비스 레이어에서 각각의 엔티티를 삭제 후 새로운 엔티티를 생성
- `구인역할 수정`(구인역할 삭제 및 생성) -> `구인역할스킬 수정`(구인역할스킬 삭제 및 생성) : 이 방법은 `구인역할 수정 `을 진행할 시점에 `recruitmentRoleSkill`가 참조한 구인역할이 사라지는 것이기 때문에 제약조건 문제가 발생합니다.

2. 삭제 로직 -> 생성 로직 따로 진행
- 이 방법은 생각보다 순서가 굉장히 중요해집니다.

1.  `recruitmentRoleSkill`을 모두 삭제 해야합니다.
2. 그 후 `recruitmentRole`를 모두 삭제해야 합니다.
3.  `recruitmentRole`를 먼저 생성해야 합니다. (왜냐하면 `recruitmentRoleSkill`은 `recruitmentRole`가 없다면 저장이 불가하기 때문입니다.)
4. 마지막으로 `recruitmentRoleSkill`를 생성합니다.

- 저는 이런식으로 구현하는게 최선이라고 생각했습니다! 물론 더 좋은 방법 있으면 말씀주세요! 
- 아무튼 이 방법은 너무 복잡하다는 생각이 들었고, 메서드간 의존관계가 너무 심하다는 생각이 들었습니다.

3. [현재 구현된 방식] `recruitmentRoleService`에서 삭제 및 생성 로직을 한 번에 진행
- 저는 이 방법이 괜찮다고 생각이 든 이유는 두 엔티티간의 라이프사이클이 같다고 생각했기 때문입니다.
- 물론 예전에는 이런식으로 구현하지 않았지만, 지금 생각해보니 `recruitmentRoleService`에서 `recruitmentRole` 과 `recruitmentRoleSkill` 엔티티를 접근해도 괜찮겠다는 생각이 들었습니다.
- 삭제 방식은 `@OnDelete` 방식으로 구현했습니다.

### 중요 포인트 2
- 바로 앞에 말씀드린 삭제 방식에 대해서 `@OnDelete`뿐만 아니라 `CascadeType.REMOVE`라는 선택지와 고민이 있었는데요!
- `CascadeType.REMOVE` 방식은, JPA에서 외래 키를 통해 참조하는 레코드들을 제거하기 위해 그 개수만큼 DELETE 쿼리를 전송한다고 합니다.
- 하지만 `@OnDelete` 방식은, JPA에서는 단일한 DELETE 쿼리만 전송하여 db단에서 참조하는 레코드들을 연쇄적으로 제거한다고 합니다.
- 물론 db단에서 어느정도의 컴퓨팅 파워가 필요할지에 대해서 까지는 알아보진 못했습니다..ㅎ
- 아무튼 쿼리 나가는 횟수만으로 이 방식에 대한 장점이 있다고 판단돼서 진행했습니다!

### 중요하진 않은? 포인트 3
- 예전에는 foreach로 save()를 했었는데요!
- saveAll()로 수정하여 나름의 성능 최적화를 해봤습니다..!
- 이후에 `exposed` 라이브러리를 사용하여 더 큰 성능차이를 만들어보겠습니다!