### PR TITLE
[DOCS] 오픈카톡방 링크 설정 API 스웨거 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.SetOpenKakaoLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetRecruitmentPostResponseDto;
@@ -115,4 +116,13 @@ public interface RecruitmentPostApi {
     @Operation(summary = "구인글 북마크 취소 API")
     ResponseEntity<Void> cancelBookmarkRecruitmentPost(@Valid @PathVariable("id") Long postId, @AuthUser User user);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "오픈 카톡방 링크 설정 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 오픈 카톡방 링크")
+            }
+    )
+    @Operation(summary = "구인글 오픈카톡 설정 API")
+    ResponseEntity<Void> setOpenKaKaoLink(@AuthUser User user, @PathVariable("id") Long postId,
+                                          SetOpenKakaoLinkRequestDto requestDto);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -29,6 +29,7 @@ import synk.meeteam.domain.recruitment.recruitment_comment.service.RecruitmentCo
 import synk.meeteam.domain.recruitment.recruitment_post.dto.RecruitmentPostMapper;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.SetOpenKakaoLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetCommentResponseDto;
@@ -188,6 +189,14 @@ public class RecruitmentPostController implements RecruitmentPostApi {
     public ResponseEntity<Void> cancelBookmarkRecruitmentPost(@Valid @PathVariable("id") Long postId,
                                                               @AuthUser User user) {
 
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PutMapping("/{id}/openTalk")
+    public ResponseEntity<Void> setOpenKaKaoLink(@AuthUser User user, @PathVariable("id") Long postId,
+                                                 @Valid @RequestBody
+                                                 SetOpenKakaoLinkRequestDto requestDto) {
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/SetOpenKakaoLinkRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/SetOpenKakaoLinkRequestDto.java
@@ -1,0 +1,13 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SetOpenKakaoLinkRequestDto(
+        @Schema(description = "링크", defaultValue = "https://open.kakao.com/o/gxlv96hg")
+        @NotBlank
+        @Pattern(regexp = "^https://open\\.kakao\\.com/", message = "오픈카톡방 링크가 잘못되었습니다.")
+        String link
+) {
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] docs 작업
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#135
- closed #135

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
오픈카톡방 링크 설정 API 스웨거 추가

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/4ef694f6-242e-43c1-93c6-7c5eca52084e)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
