### PR TITLE
[DOCS] 댓글 등록 API 스웨거 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
@@ -21,7 +21,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetRecruitm
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.security.AuthUser;
 
-@Tag(name = "recruitment", description = "구인 관련 API")
+// @Tags({@Tag(name = "recruitment", description = "구인 관련 API"), @Tag(name = "comment", description = "댓글 관련 API")})
 public interface RecruitmentPostApi {
 
     @ApiResponses(
@@ -29,7 +29,7 @@ public interface RecruitmentPostApi {
                     @ApiResponse(responseCode = "201", description = "구인글 생성 성공"),
             }
     )
-    @Operation(summary = "구인글 생성 API")
+    @Operation(summary = "구인글 생성 API", tags = {"recruitment"})
     ResponseEntity<CreateRecruitmentPostResponseDto> createRecruitmentPost(
             @Valid @RequestBody CreateRecruitmentPostRequestDto requestDto);
 
@@ -41,7 +41,7 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "특정 구인글 조회 API")
+    @Operation(summary = "특정 구인글 조회 API", tags = {"recruitment"})
     @SecurityRequirements
     ResponseEntity<GetRecruitmentPostResponseDto> getRecruitmentPost(
             @PathVariable("id") Long postId);
@@ -52,7 +52,7 @@ public interface RecruitmentPostApi {
                     @ApiResponse(responseCode = "200", description = "신청 정보 조회 성공"),
             }
     )
-    @Operation(summary = "신청 정보 조회 API")
+    @Operation(summary = "신청 정보 조회 API", tags = {"recruitment"})
     ResponseEntity<GetApplyInfoResponseDto> getApplyInfo(@PathVariable("id") Long postId,
                                                          @AuthUser User user);
 
@@ -64,7 +64,7 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "구인 신청 API")
+    @Operation(summary = "구인 신청 API", tags = {"recruitment"})
     ResponseEntity<Void> applyRecruitment(@PathVariable("id") Long postId,
                                           @Valid @RequestBody ApplyRecruitmentRequestDto requestDto,
                                           @AuthUser User user);
@@ -77,7 +77,7 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "구인 마감 API")
+    @Operation(summary = "구인 마감 API", tags = {"recruitment"})
     ResponseEntity<Void> closeRecruitment(@PathVariable("id") Long postId, @AuthUser User user);
 
     @ApiResponses(
@@ -88,7 +88,7 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "구인글 수정 API")
+    @Operation(summary = "구인글 수정 API", tags = {"recruitment"})
     ResponseEntity<Void> modifyRecruitmentPost(@Valid @RequestBody CreateRecruitmentPostRequestDto requestDto,
                                                @PathVariable("id") Long postId, @AuthUser User user);
 
@@ -100,7 +100,7 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "구인글 북마크 API")
+    @Operation(summary = "구인글 북마크 API", tags = {"recruitment"})
     ResponseEntity<Void> bookmarkRecruitmentPost(@PathVariable("id") Long postId, @AuthUser User user);
 
     @ApiResponses(
@@ -111,7 +111,19 @@ public interface RecruitmentPostApi {
                     })
             }
     )
-    @Operation(summary = "구인글 북마크 취소 API")
+    @Operation(summary = "구인글 북마크 취소 API", tags = {"recruitment"})
     ResponseEntity<Void> cancelBookmarkRecruitmentPost(@PathVariable("id") Long postId, @AuthUser User user);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "댓글 등록 성공"
+                            , content = {
+                            @Content(mediaType = APPLICATION_JSON_VALUE)
+                    })
+            }
+    )
+    @Operation(summary = "댓글 등록 API", tags = {"comment"})
+    ResponseEntity<Void> registerComment(@PathVariable("id") Long postId,
+                                         @Valid @RequestBody CreateCommentRequestDto requestDto, @AuthUser User user);
 
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -27,6 +27,7 @@ import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentA
 import synk.meeteam.domain.recruitment.recruitment_comment.service.RecruitmentCommentService;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.RecruitmentPostMapper;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
@@ -187,6 +188,15 @@ public class RecruitmentPostController implements RecruitmentPostApi {
                                                               @AuthUser User user) {
         recruitmentPostFacade.cancelBookmarkRecruitmentPost(postId, user);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/comment")
+    @Override
+    public ResponseEntity<Void> registerComment(@PathVariable("id") Long postId,
+                                                @Valid @RequestBody CreateCommentRequestDto requestDto,
+                                                @AuthUser User user) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/CreateCommentRequestDto.java
@@ -1,0 +1,18 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CreateCommentRequestDto", description = "댓글 등록 요청 Dto")
+public record CreateCommentRequestDto(
+
+        @Schema(description = "댓글 내용", example = "나 진짜 관심있어여")
+        String content,
+        @Schema(description = "댓글/대댓글 여부, 대댓글이면 false", example = "true")
+        boolean isParent,
+        @Schema(description = "댓글 그룹 번호", example = "2")
+        long groupNumber,
+        @Schema(description = "특정 댓글 그룹 내 순서", example = "3")
+        long groupOrder
+
+) {
+}

--- a/src/main/java/synk/meeteam/global/config/SwaggerConfig.java
+++ b/src/main/java/synk/meeteam/global/config/SwaggerConfig.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
 import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,6 +61,17 @@ public class SwaggerConfig {
         info.setServers(Arrays.asList(devServer, localServer));
 
         return info;
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Your API").version("1.0.0"))
+                .tags(List.of(
+                                new Tag().name("recruitment").description("구인 관련 API"),
+                                new Tag().name("comment").description("댓글 관련 API")
+                        )
+                );
     }
 
     private Info apiInfo() {


### PR DESCRIPTION
## 📝 PR 타입
- [x] docs 작업
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #139 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 댓글 등록 API 스웨거 추가했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

<img width="1181" alt="스크린샷 2024-03-27 오후 6 19 11" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/5501b1b8-1739-45cd-9c32-00ad2074ff02">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
<img width="1231" alt="스크린샷 2024-03-27 오후 6 25 27" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/59b5f691-659b-43a1-abeb-124f65d7355d">


- 구인쪽 API가 점점 많아지는 것 같아서 댓글 부분만 따로 분리해봤는데 의견 궁금합니다!
- 더 나눌려다가 오히려 더 나누면 복잡해질 거 같아서 일단 댓글 부분만 뺴봤습니다.
- 보시는데 불편하지 않으셨다면, 이렇게 분리하지 않고 기존 방식대로 진행하겠습니다!