### PR TITLE
[DOCS] 구인글 목록 검색 조회 API 스웨거 작성

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -10,14 +10,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetRecruitmentPostResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.response.PaginationSearchPostResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.security.AuthUser;
 
@@ -113,5 +116,23 @@ public interface RecruitmentPostApi {
     )
     @Operation(summary = "구인글 북마크 취소 API")
     ResponseEntity<Void> cancelBookmarkRecruitmentPost(@PathVariable("id") Long postId, @AuthUser User user);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "검색 성공"),
+                    @ApiResponse(responseCode = "403", description = "접근 권한이 없습니다")
+            }
+    )
+    @Operation(summary = "구인글 목록 검색 API")
+    ResponseEntity<PaginationSearchPostResponseDto> searchRecruitmentPost(
+            @RequestParam Long fieldId,
+            @RequestParam Long scopeIndex,
+            @RequestParam Long categoryIndex,
+            @RequestParam List<Long> skills,
+            @RequestParam List<Long> roles,
+            @RequestParam List<Long> tags,
+            @RequestParam String keyword
+    );
+
 
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.field.service.FieldService;
@@ -32,6 +33,8 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecru
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetCommentResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetRecruitmentPostResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.response.PaginationSearchPostResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.response.SearchRecruitmentPostsResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.facade.RecruitmentPostFacade;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
@@ -44,6 +47,7 @@ import synk.meeteam.domain.recruitment.recruitment_tag.service.RecruitmentTagSer
 import synk.meeteam.domain.recruitment.recruitment_tag.service.vo.RecruitmentTagVO;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.UserService;
+import synk.meeteam.global.dto.PageInfo;
 import synk.meeteam.infra.s3.S3FileName;
 import synk.meeteam.infra.s3.service.S3Service;
 import synk.meeteam.security.AuthUser;
@@ -189,6 +193,34 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/search")
+    @Override
+    public ResponseEntity<PaginationSearchPostResponseDto> searchRecruitmentPost(
+            @RequestParam(value = "field", required = false) Long fieldId,
+            @RequestParam(value = "scope", required = false) Long scopeIndex,
+            @RequestParam(value = "category", required = false) Long categoryIndex,
+            @RequestParam(value = "skill", required = false) List<Long> skills,
+            @RequestParam(value = "role", required = false) List<Long> roles,
+            @RequestParam(value = "tag", required = false) List<Long> tags,
+            @RequestParam(value = "keyword", required = false) String keyword) {
+        return ResponseEntity.ok(
+                new PaginationSearchPostResponseDto(
+                        List.of(
+                                new SearchRecruitmentPostsResponseDto(
+                                        1L,
+                                        "구인합니다",
+                                        "프로젝트",
+                                        "goder",
+                                        "https://image.png",
+                                        "2024-12-15",
+                                        "",
+                                        true
+                                )
+                        ),
+                        new PageInfo(1L, 24L, 10L, 1L)
+                )
+        );
+    }
 
     ////////////////  변환 로직들  ////////////////
     private List<RecruitmentRole> getRecruitmentRoles(CreateRecruitmentPostRequestDto requestDto,

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/PaginationSearchPostResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/PaginationSearchPostResponseDto.java
@@ -1,0 +1,10 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.response;
+
+import java.util.List;
+import synk.meeteam.global.dto.PageInfo;
+
+public record PaginationSearchPostResponseDto(
+        List<SearchRecruitmentPostsResponseDto> posts,
+        PageInfo pageInfo
+) {
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/SearchRecruitmentPostsResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/SearchRecruitmentPostsResponseDto.java
@@ -1,0 +1,23 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SearchRecruitmentPostsResponseDto(
+        @Schema(description = "글 id", example = "1")
+        Long id,
+        @Schema(description = "글 제목", example = "팀원을 구합니다!")
+        String title,
+        @Schema(description = "유형", example = "프로젝트")
+        String category,
+        @Schema(description = "작성자 닉네임", example = "song123")
+        String writerNickname,
+        @Schema(description = "작성자 사진", example = "url 형태")
+        String writerProfileImg,
+        @Schema(description = "구인 마감 날짜", example = "2024-03-10")
+        String deadline,
+        @Schema(description = "범위", example = "교내")
+        String scope,
+        @Schema(description = "북마크 여부", example = "true")
+        Boolean isBookmarked
+) {
+}

--- a/src/main/java/synk/meeteam/global/dto/PageInfo.java
+++ b/src/main/java/synk/meeteam/global/dto/PageInfo.java
@@ -1,0 +1,15 @@
+package synk.meeteam.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PageInfo(
+        @Schema(description = "현재 페이지", example = "1")
+        Long page,
+        @Schema(description = "개수", example = "10")
+        Long size,
+        @Schema(description = "모든 개수", example = "30")
+        Long totalContents,
+        @Schema(description = "전체 페이지 수", example = "3")
+        Long totalPages
+) {
+}

--- a/src/main/java/synk/meeteam/security/config/SecurityConfig.java
+++ b/src/main/java/synk/meeteam/security/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
     private static final String[] SEMI_AUTH_WHITELIST = {
             // 꼭 GET만 가능해야 하는 리스트
             "/recruitment/postings/{id}",
+            "/recruitment/postings/search",
             "/user/profile/**"
     };
 


### PR DESCRIPTION
## 📝 PR 타입
- [x] docs 작업
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#142
- closed #142

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
구인글 목록 검색 조회 API 스웨거 작성하였습니다.

### enum 관련 id 정보
| id | category |
|:--|:----:|
| 1 | 프로젝트 |
| 2 | 스터디  |
| 3 | 공모전  |  

| id | scope |
|:--|:----:|
| 1 | 교외 |
| 2 | 교내  |  

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/c42da942-40ed-406e-a567-9bd576f34c6c)
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/7caf5db5-fc10-450d-935c-1a37dba04da2)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
분야의 경우에는 현재 db에 저장하며 id는 1(개발)로 고정입니다!
분야 조회 API를 간단히 추가하는 것도 좋을 것 같네요!