### PR TITLE
[FEAT] 댓글 등록 API

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -34,7 +34,7 @@ public class RecruitmentComment extends BaseEntity {
 
     //내용
     @NotNull
-    @Size(max = 100)
+    @Size(min = 1, max = 100)
     @Column(length = 100)
     private String content;
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -15,13 +15,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.global.entity.BaseEntity;
 
 @Getter
-@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecruitmentComment extends BaseEntity {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentException.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentException.java
@@ -1,0 +1,10 @@
+package synk.meeteam.domain.recruitment.recruitment_comment.exception;
+
+import synk.meeteam.global.common.exception.BaseCustomException;
+import synk.meeteam.global.common.exception.ExceptionType;
+
+public class RecruitmentCommentException extends BaseCustomException {
+    public RecruitmentCommentException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentExceptionType.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentExceptionType.java
@@ -1,0 +1,23 @@
+package synk.meeteam.domain.recruitment.recruitment_comment.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import synk.meeteam.global.common.exception.ExceptionType;
+
+@RequiredArgsConstructor
+public enum RecruitmentCommentExceptionType implements ExceptionType {
+    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "잘못된 댓글 등록 요청입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -1,10 +1,24 @@
 package synk.meeteam.domain.recruitment.recruitment_comment.repository;
 
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
+
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 
 
 public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentComment, Long>,
         RecruitmentCommentRepositoryCustom {
 
+    Optional<RecruitmentComment> findFirstByRecruitmentPostOrderByGroupNumberDesc(RecruitmentPost recruitmentPost);
+
+    Optional<RecruitmentComment> findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(
+            RecruitmentPost recruitmentPost, long groupNumber);
+
+    default RecruitmentComment findLatestGroupOrderOrElseThrow(RecruitmentPost recruitmentPost, long groupNumber) {
+        return findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(recruitmentPost, groupNumber).orElseThrow(
+                () -> new RecruitmentCommentException(INVALID_COMMENT));
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -1,9 +1,14 @@
 package synk.meeteam.domain.recruitment.recruitment_comment.service;
 
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
 import synk.meeteam.domain.recruitment.recruitment_comment.repository.RecruitmentCommentRepository;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.vo.RecruitmentCommentVO;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetCommentResponseDto;
@@ -50,5 +55,40 @@ public class RecruitmentCommentService {
         }
 
         return groupedComments;
+    }
+
+    @Transactional
+    public RecruitmentComment registerRecruitmentComment(RecruitmentComment recruitmentComment) {
+        validateComment(recruitmentComment);
+
+        return recruitmentCommentRepository.save(recruitmentComment);
+    }
+
+    private void validateComment(RecruitmentComment recruitmentComment) {
+        long nextGroupNumber = 1;
+        long nextGroupOrder = 1;
+
+        if (recruitmentComment.isParent()) {  // 페치 조인으로 변경하는게 좋을듯?
+            // 댓글인 경우
+            // 현재 가장 최신 그룹 번호를 찾아서, 그 다음 번호로 할당 + 그룹오더 1로 할당
+            RecruitmentComment foundRecruitmentComment = recruitmentCommentRepository.findFirstByRecruitmentPostOrderByGroupNumberDesc(
+                    recruitmentComment.getRecruitmentPost()).orElse(null);
+            if (foundRecruitmentComment != null) {
+                nextGroupNumber = foundRecruitmentComment.getGroupNumber() + 1;
+            }
+
+        } else if (!recruitmentComment.isParent()) {
+            // 대댓글인 경우
+            // 해당 그룹 번호가 있는지 찾아서, 그 그룹 오더 가장 최신 번호 찾아서, 그 다음 번호로 할당
+            RecruitmentComment foundRecruitmentComment = recruitmentCommentRepository.findLatestGroupOrderOrElseThrow(
+                    recruitmentComment.getRecruitmentPost(), recruitmentComment.getGroupNumber());
+
+            nextGroupOrder = foundRecruitmentComment.getGroupOrder() + 1;
+        }
+
+        if (nextGroupNumber != recruitmentComment.getGroupNumber()
+                || nextGroupOrder != recruitmentComment.getGroupOrder()) {
+            throw new RecruitmentCommentException(INVALID_COMMENT);
+        }
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -26,6 +26,7 @@ import synk.meeteam.domain.common.tag.entity.Tag;
 import synk.meeteam.domain.common.tag.entity.TagType;
 import synk.meeteam.domain.recruitment.bookmark.service.BookmarkService;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.RecruitmentCommentService;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.RecruitmentPostMapper;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
@@ -244,7 +245,11 @@ public class RecruitmentPostController implements RecruitmentPostApi {
     public ResponseEntity<Void> registerComment(@PathVariable("id") Long postId,
                                                 @Valid @RequestBody CreateCommentRequestDto requestDto,
                                                 @AuthUser User user) {
+        RecruitmentPost recruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
+        RecruitmentComment recruitmentComment = recruitmentPostMapper.toRecruitmentCommentEntity(recruitmentPost,
+                requestDto);
 
+        recruitmentCommentService.registerRecruitmentComment(recruitmentComment);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/RecruitmentPostMapper.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/RecruitmentPostMapper.java
@@ -9,6 +9,8 @@ import synk.meeteam.domain.common.skill.entity.Skill;
 import synk.meeteam.domain.common.tag.entity.Tag;
 import synk.meeteam.domain.common.tag.entity.TagType;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
@@ -36,6 +38,9 @@ public interface RecruitmentPostMapper {
     @Mapping(source = "user", target = "applicant")
     RecruitmentApplicant toRecruitmentApplicantEntity(RecruitmentPost recruitmentPost, Role role, User user,
                                                       String comment);
+
+    @Mapping(source = "requestDto.content", target = "content")
+    RecruitmentComment toRecruitmentCommentEntity(RecruitmentPost recruitmentPost, CreateCommentRequestDto requestDto);
 
     @Mapping(source = "name", target = "name")
     @Mapping(source = "type", target = "type")

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/CreateCommentRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/CreateCommentRequestDto.java
@@ -1,13 +1,18 @@
 package synk.meeteam.domain.recruitment.recruitment_post.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(name = "CreateCommentRequestDto", description = "댓글 등록 요청 Dto")
 public record CreateCommentRequestDto(
 
         @Schema(description = "댓글 내용", example = "나 진짜 관심있어여")
+        @NotNull
+        @Size(min = 1, max = 100)
         String content,
         @Schema(description = "댓글/대댓글 여부, 대댓글이면 false", example = "true")
+        @NotNull
         boolean isParent,
         @Schema(description = "댓글 그룹 번호", example = "2")
         long groupNumber,

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentRepositoryTest.java
@@ -1,19 +1,29 @@
 package synk.meeteam.domain.recruitment.recruitment_comment;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
 import synk.meeteam.domain.recruitment.recruitment_comment.repository.RecruitmentCommentRepository;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.vo.RecruitmentCommentVO;
+import synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
+import synk.meeteam.domain.recruitment.recruitment_post.repository.RecruitmentPostRepository;
 
 @DataJpaTest
 @ActiveProfiles("test")
 public class RecruitmentCommentRepositoryTest {
+    private static String CONTENT_EXCEED_100 = "이 내용은 100자가 넘는 내용입니다.이 내용은 100자가 넘는 내용입니다.이 내용은 100자가 넘는 내용입니다.이 내용은 100자가 넘는 내용입니다.이 내용은 100자가 넘는 내용";
+
     @Autowired
     private RecruitmentCommentRepository recruitmentCommentRepository;
+
+    @Autowired
+    private RecruitmentPostRepository recruitmentPostRepository;
 
     @Test
     void 댓글조회_댓글반환_구인글id로조회() {
@@ -28,5 +38,28 @@ public class RecruitmentCommentRepositoryTest {
             Assertions.assertThat(vo.getNickname()).isEqualTo("송민규짱짱맨");
         }
 
+    }
+
+    @Test
+    void 댓글등록_예외발생_댓글내용100자넘는경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        recruitmentPostRepository.save(recruitmentPost);
+        long groupNumber = 1L;
+        long groupOrder = 1L;
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content(CONTENT_EXCEED_100)
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentRepository.save(comment))
+                .isInstanceOf(ConstraintViolationException.class);
+
+        // then
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
@@ -1,14 +1,21 @@
 package synk.meeteam.domain.recruitment.recruitment_comment;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
 
 import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
 import synk.meeteam.domain.recruitment.recruitment_comment.repository.RecruitmentCommentRepository;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.RecruitmentCommentService;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.vo.RecruitmentCommentVO;
@@ -57,4 +64,203 @@ public class RecruitmentCommentServiceTest {
                 .containsExactly("닉네임입니다3", false);
 
     }
+
+    @Test
+    void 댓글등록_성공_최초댓글경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        long groupNumber = 1L;
+        long groupOrder = 1L;
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(comment).when(recruitmentCommentRepository).save(any());
+        doReturn(Optional.ofNullable(null)).when(recruitmentCommentRepository)
+                .findFirstByRecruitmentPostOrderByGroupNumberDesc(recruitmentPost);
+
+        // when
+        RecruitmentComment savedRecruitmentComment = recruitmentCommentService.registerRecruitmentComment(comment);
+
+        // then
+        Assertions.assertThat(savedRecruitmentComment)
+                .extracting("content", "isParent", "groupNumber", "groupOrder")
+                .containsExactly("저 하고 싶어요", true, groupNumber, groupOrder);
+    }
+
+    @Test
+    void 댓글등록_성공_이전댓글있는경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        long prevGroupNumber = 1L;
+        long prevGroupOrder = 1L;
+
+        long groupNumber = 2L;
+        long groupOrder = 1L;
+
+        RecruitmentComment prevComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(prevGroupNumber)
+                .groupOrder(prevGroupOrder)
+                .build();
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(comment).when(recruitmentCommentRepository).save(any());
+        doReturn(Optional.ofNullable(prevComment)).when(recruitmentCommentRepository)
+                .findFirstByRecruitmentPostOrderByGroupNumberDesc(recruitmentPost);
+
+        // when
+        RecruitmentComment savedRecruitmentComment = recruitmentCommentService.registerRecruitmentComment(comment);
+
+        // then
+        Assertions.assertThat(savedRecruitmentComment)
+                .extracting("content", "isParent", "groupNumber", "groupOrder")
+                .containsExactly("저 하고 싶어요", true, groupNumber, groupOrder);
+    }
+
+    @Test
+    void 대댓글등록_성공() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        long parentGroupNumber = 1L;
+        long parentGroupOrder = 1L;
+
+        long groupNumber = 1L;
+        long groupOrder = 2L;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(parentGroupNumber)
+                .groupOrder(parentGroupOrder)
+                .build();
+
+        RecruitmentComment childComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(false)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(childComment).when(recruitmentCommentRepository).save(any());
+        doReturn(parentComment).when(recruitmentCommentRepository)
+                .findLatestGroupOrderOrElseThrow(recruitmentPost, groupNumber);
+
+        // when
+        RecruitmentComment savedRecruitmentComment = recruitmentCommentService.registerRecruitmentComment(childComment);
+
+        // then
+        Assertions.assertThat(savedRecruitmentComment)
+                .extracting("content", "isParent", "groupNumber", "groupOrder")
+                .containsExactly("저 하고 싶어요", false, groupNumber, groupOrder);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,1", "1,2", "1,0", "2,1", "2,2"})
+    void 댓글등록_예외발생_댓글의groupNumber나groupOrder가잘못된경우(long groupNumber, long groupOrder) {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(Optional.ofNullable(null)).when(recruitmentCommentRepository)
+                .findFirstByRecruitmentPostOrderByGroupNumberDesc(recruitmentPost);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentService.registerRecruitmentComment(comment))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_COMMENT.message());
+    }
+
+
+    @ParameterizedTest
+    @CsvSource(value = {"2,1", "2,4", "2,0"})
+    void 대댓글등록_예외발생_대댓글의groupNumber나groupOrder가잘못된경우(long groupNumber, long groupOrder) {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        long parentGroupNumber = 2L;
+        long parentGroupOrder = 2L;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(parentGroupNumber)
+                .groupOrder(parentGroupOrder)
+                .build();
+
+        RecruitmentComment childComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(false)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(parentComment).when(recruitmentCommentRepository)
+                .findLatestGroupOrderOrElseThrow(recruitmentPost, groupNumber);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentService.registerRecruitmentComment(childComment))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_COMMENT.message());
+    }
+
+    @Test
+    void 대댓글등록_예외발생_존재하지않은groupNumer경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("제목입니당");
+        long parentGroupNumber = 2L;
+        long parentGroupOrder = 2L;
+
+        long groupNumber = 5L;
+        long groupOrder = 2L;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(parentGroupNumber)
+                .groupOrder(parentGroupOrder)
+                .build();
+
+        RecruitmentComment childComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(false)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        doReturn(parentComment).when(recruitmentCommentRepository)
+                .findLatestGroupOrderOrElseThrow(recruitmentPost, groupNumber);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentService.registerRecruitmentComment(childComment))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_COMMENT.message());
+    }
+
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #154

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 댓글 등록 API 구현했습니다.
- 검증로직도 구현해봤습니다.

## 📝 테스트 결과
<img width="944" alt="스크린샷 2024-03-29 오후 1 34 43" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/e5b37403-15dc-4cb7-a101-9136da6b95e6">
<img width="870" alt="스크린샷 2024-03-29 오후 1 34 48" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/13e5d07d-deb6-4ee1-9bd8-df8b257e7ccd">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 기존에 댓글 최대 글자 100자 조건이 있었는데, 최소 조건이 아예 없는 게 어색할거 같아서 1자로 정했습니다! 의견 궁금합니다!
- 로직이 그렇게 복잡하지 않은데 그나마 포인트는 댓글 등록을 위해 validation 하는 로직일 것 같습니다!