### PR TITLE
[DOCS] 댓글 삭제 API 스웨거 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.DeleteCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.SetOpenKakaoLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
@@ -161,5 +162,17 @@ public interface RecruitmentPostApi {
     @Operation(summary = "댓글 등록 API", tags = {"comment"})
     ResponseEntity<Void> registerComment(@PathVariable("id") Long postId,
                                          @Valid @RequestBody CreateCommentRequestDto requestDto, @AuthUser User user);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"
+                            , content = {
+                            @Content(mediaType = APPLICATION_JSON_VALUE)
+                    })
+            }
+    )
+    @Operation(summary = "댓글 삭제 API", tags = {"comment"})
+    ResponseEntity<Void> deleteComment(@PathVariable("id") Long postId,
+                                       @Valid @RequestBody DeleteCommentRequestDto requestDto, @AuthUser User user);
 
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -33,6 +33,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.SearchCondition;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruitmentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.DeleteCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.SetOpenKakaoLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
@@ -239,6 +240,12 @@ public class RecruitmentPostController implements RecruitmentPostApi {
                                                 @AuthUser User user) {
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/{id}/comment")
+    @Override
+    public ResponseEntity<Void> deleteComment(Long postId, DeleteCommentRequestDto requestDto, User user) {
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -242,7 +242,7 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PatchMapping("/{id}/comment")
+    @DeleteMapping("/{id}/comment")
     @Override
     public ResponseEntity<Void> deleteComment(Long postId, DeleteCommentRequestDto requestDto, User user) {
         return ResponseEntity.ok().build();

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/DeleteCommentRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/DeleteCommentRequestDto.java
@@ -1,0 +1,12 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DeleteCommentRequestDto", description = "댓글 삭제 요청 Dto")
+public record DeleteCommentRequestDto(
+        @Schema(description = "댓글 그룹 번호", example = "2")
+        long groupNumber,
+        @Schema(description = "특정 댓글 그룹 내 순서", example = "3")
+        long groupOrder
+) {
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] docs 작업
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #157 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
<img width="1175" alt="스크린샷 2024-03-29 오후 4 41 05" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/d8bb8a29-e6e5-4931-a429-d252158df8e5">



## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 메서드를 delete로 하려다가, 저희가 실제 db에 아예 완전 삭제시키는게 아니라 boolean 값만 바꾸고, 데이터를 남겨두고는 있어서 patch로 해봤습니다..! 의견 궁금합니다!
- 요청 url : PATCH {{domain}}/recruitment/postings/1/comment
- 요청 바디 : 
```
{
  "groupNumber": 2,
  "groupOrder": 3
}
```