### PR TITLE
[FEAT] 댓글 삭제 API

### DIFF
--- a/src/main/java/synk/meeteam/domain/common/course/entity/Professor.java
+++ b/src/main/java/synk/meeteam/domain/common/course/entity/Professor.java
@@ -16,13 +16,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import synk.meeteam.domain.common.university.entity.University;
+import synk.meeteam.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Professor {
+public class Professor extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "professor_id")

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -66,4 +66,8 @@ public class RecruitmentComment extends BaseEntity {
         this.groupNumber = groupNumber;
         this.groupOrder = groupOrder;
     }
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.recruitment.recruitment_comment.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_USER;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.global.entity.BaseEntity;
 
@@ -69,5 +71,11 @@ public class RecruitmentComment extends BaseEntity {
 
     public void softDelete() {
         this.isDeleted = true;
+    }
+
+    public void validateWriter(Long userId) {
+        if (!this.getCreatedBy().equals(userId)) {
+            throw new RecruitmentCommentException(INVALID_USER);
+        }
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -69,8 +69,17 @@ public class RecruitmentComment extends BaseEntity {
         this.groupOrder = groupOrder;
     }
 
-    public void softDelete() {
+    public void softDelete(Long userId) {
+        validateWriter(userId);
+
         this.isDeleted = true;
+    }
+
+    public boolean hasChildComment(long latestGroupOrder) {
+        if (this.isParent && (this.groupOrder != latestGroupOrder)) {
+            return true;
+        }
+        return false;
     }
 
     public void validateWriter(Long userId) {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentExceptionType.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/exception/RecruitmentCommentExceptionType.java
@@ -6,7 +6,8 @@ import synk.meeteam.global.common.exception.ExceptionType;
 
 @RequiredArgsConstructor
 public enum RecruitmentCommentExceptionType implements ExceptionType {
-    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "잘못된 댓글 등록 요청입니다.");
+    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "잘못된 댓글 등록 요청입니다."),
+    INVALID_USER(HttpStatus.BAD_REQUEST, "해당 댓글의 수정 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -21,4 +21,8 @@ public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentC
         return findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(recruitmentPost, groupNumber).orElseThrow(
                 () -> new RecruitmentCommentException(INVALID_COMMENT));
     }
+
+    default RecruitmentComment findByIdOrElseThrow(Long commentId) {
+        return findById(commentId).orElseThrow(() -> new RecruitmentCommentException(INVALID_COMMENT));
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -14,11 +14,11 @@ public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentC
 
     Optional<RecruitmentComment> findFirstByRecruitmentPostOrderByGroupNumberDesc(RecruitmentPost recruitmentPost);
 
-    Optional<RecruitmentComment> findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(
+    Optional<RecruitmentComment> findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrderDesc(
             RecruitmentPost recruitmentPost, long groupNumber);
 
     default RecruitmentComment findLatestGroupOrderOrElseThrow(RecruitmentPost recruitmentPost, long groupNumber) {
-        return findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(recruitmentPost, groupNumber).orElseThrow(
+        return findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrderDesc(recruitmentPost, groupNumber).orElseThrow(
                 () -> new RecruitmentCommentException(INVALID_COMMENT));
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepositoryCustomImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepositoryCustomImpl.java
@@ -26,7 +26,7 @@ public class RecruitmentCommentRepositoryCustomImpl implements RecruitmentCommen
                 .from(recruitmentComment)
                 .leftJoin(user)
                 .on(recruitmentComment.createdBy.eq(user.id))
-                .where(recruitmentComment.recruitmentPost.id.eq(postId), recruitmentComment.isDeleted.eq(false))
+                .where(recruitmentComment.recruitmentPost.id.eq(postId))
                 .orderBy(recruitmentComment.groupNumber.asc(), recruitmentComment.createdAt.asc())
                 .fetch();
     }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -22,7 +22,6 @@ import synk.meeteam.infra.s3.service.S3Service;
 @Service
 @RequiredArgsConstructor
 public class RecruitmentCommentService {
-    private static final String DELETE_MESSAGE = "삭제된 댓글입니다.";
 
     private final RecruitmentCommentRepository recruitmentCommentRepository;
     private final S3Service s3Service;
@@ -41,12 +40,23 @@ public class RecruitmentCommentService {
             String profileImg = s3Service.createPreSignedGetUrl(
                     S3FileName.USER,
                     comment.getProfileImg());
+            String commentWriterId = Encryption.encryptLong(comment.getUserId());
+            String nickname = comment.getNickname();
+            String content = comment.getContent();
+
+            if (comment.isDeleted()) {
+                isWriter = false;
+                profileImg = null;
+                commentWriterId = null;
+                nickname = null;
+                content = null;
+            }
+
             if (comment.isParent()) {
                 List<GetReplyResponseDto> replies = new ArrayList<>();
                 groupedComments.add(
-                        new GetCommentResponseDto(comment.getId(), Encryption.encryptLong(comment.getUserId()),
-                                comment.getNickname(), profileImg,
-                                comment.getContent(), comment.getCreateAt(), isWriter, comment.getGroupNumber(),
+                        new GetCommentResponseDto(comment.getId(), commentWriterId, nickname, profileImg,
+                                content, comment.getCreateAt(), isWriter, comment.getGroupNumber(),
                                 comment.getGroupOrder(), replies));
                 continue;
             }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -78,10 +78,8 @@ public class RecruitmentCommentService {
         RecruitmentComment latestRecruitmentComment = recruitmentCommentRepository.findLatestGroupOrderOrElseThrow(
                 recruitmentPost, recruitmentComment.getGroupNumber());
 
-        if (recruitmentComment.isParent()
-                && (latestRecruitmentComment.getGroupOrder() != recruitmentComment.getGroupOrder())) {
-
-            recruitmentComment.softDelete();
+        if (recruitmentComment.hasChildComment(latestRecruitmentComment.getGroupOrder())) {
+            recruitmentComment.softDelete(userId);
             return;
         }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -79,7 +79,7 @@ public class RecruitmentCommentService {
                 recruitmentPost, recruitmentComment.getGroupNumber());
 
         if (recruitmentComment.isParent()
-                && (latestRecruitmentComment.getGroupOrder() == recruitmentComment.getGroupOrder())) {
+                && (latestRecruitmentComment.getGroupOrder() != recruitmentComment.getGroupOrder())) {
 
             recruitmentComment.softDelete();
             return;
@@ -116,7 +116,7 @@ public class RecruitmentCommentService {
     }
 
     private long getNewGroupOrder(RecruitmentPost recruitmentPost, long groupNumber) {
-        RecruitmentComment recruitmentComment = recruitmentCommentRepository.findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(
+        RecruitmentComment recruitmentComment = recruitmentCommentRepository.findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrderDesc(
                 recruitmentPost, groupNumber).orElse(null);
 
         if (recruitmentComment == null) {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -40,22 +40,12 @@ public class RecruitmentCommentService {
                     S3FileName.USER,
                     comment.getProfileImg());
             String commentWriterId = Encryption.encryptLong(comment.getUserId());
-            String nickname = comment.getNickname();
-            String content = comment.getContent();
-
-            if (comment.isDeleted()) {
-                isWriter = false;
-                profileImg = null;
-                commentWriterId = null;
-                nickname = null;
-                content = null;
-            }
 
             if (comment.isParent()) {
                 List<GetReplyResponseDto> replies = new ArrayList<>();
                 groupedComments.add(
-                        new GetCommentResponseDto(comment.getId(), commentWriterId, nickname, profileImg,
-                                content, comment.getCreateAt(), isWriter, comment.getGroupNumber(),
+                        new GetCommentResponseDto(comment.getId(), commentWriterId, comment.getNickname(), profileImg,
+                                comment.getContent(), comment.getCreateAt(), isWriter, comment.getGroupNumber(),
                                 comment.getGroupOrder(), replies));
                 continue;
             }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -1,7 +1,6 @@
 package synk.meeteam.domain.recruitment.recruitment_comment.service;
 
 import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
-import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_USER;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,10 +73,7 @@ public class RecruitmentCommentService {
     public void deleteComment(Long commentId, Long userId, RecruitmentPost recruitmentPost) {
         RecruitmentComment recruitmentComment = recruitmentCommentRepository.findByIdOrElseThrow(commentId);
 
-        // 검증 로직
-        if (!recruitmentComment.getCreatedBy().equals(userId)) {
-            throw new RecruitmentCommentException(INVALID_USER);
-        }
+        recruitmentComment.validateWriter(userId);
 
         RecruitmentComment latestRecruitmentComment = recruitmentCommentRepository.findLatestGroupOrderOrElseThrow(
                 recruitmentPost, recruitmentComment.getGroupNumber());

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/vo/RecruitmentCommentVO.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/vo/RecruitmentCommentVO.java
@@ -34,4 +34,32 @@ public class RecruitmentCommentVO {
         this.groupOrder = groupOrder;
         this.isDeleted = isDeleted;
     }
+
+    public Long getUserId() {
+        if (isDeleted) {
+            return null;
+        }
+        return userId;
+    }
+
+    public String getProfileImg() {
+        if (isDeleted) {
+            return null;
+        }
+        return profileImg;
+    }
+
+    public String getNickname() {
+        if (isDeleted) {
+            return null;
+        }
+        return nickname;
+    }
+
+    public String getContent() {
+        if (isDeleted) {
+            return null;
+        }
+        return content;
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -250,7 +250,13 @@ public class RecruitmentPostController implements RecruitmentPostApi {
 
     @DeleteMapping("/{id}/comment")
     @Override
-    public ResponseEntity<Void> deleteComment(Long postId, DeleteCommentRequestDto requestDto, User user) {
+    public ResponseEntity<Void> deleteComment(@PathVariable("id") Long postId,
+                                              @Valid @RequestBody DeleteCommentRequestDto requestDto,
+                                              @AuthUser User user) {
+
+        RecruitmentPost recruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
+        recruitmentCommentService.deleteComment(requestDto.commentId(), user.getId(), recruitmentPost);
+
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/DeleteCommentRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/DeleteCommentRequestDto.java
@@ -4,9 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "DeleteCommentRequestDto", description = "댓글 삭제 요청 Dto")
 public record DeleteCommentRequestDto(
-        @Schema(description = "댓글 그룹 번호", example = "2")
-        long groupNumber,
-        @Schema(description = "특정 댓글 그룹 내 순서", example = "3")
-        long groupOrder
+        @Schema(description = "댓글 id", example = "2")
+        long commentId
 ) {
 }

--- a/src/main/java/synk/meeteam/global/util/Encryption.java
+++ b/src/main/java/synk/meeteam/global/util/Encryption.java
@@ -22,6 +22,10 @@ public class Encryption {
     }
 
     public static String encryptLong(Long value) {
+        if (value == null) {
+            return null;
+        }
+
         try {
             SecretKeySpec keySpec = new SecretKeySpec(SECRET_KEY.getBytes(), ALGORITHM);
             Cipher cipher = Cipher.getInstance(ALGORITHM);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantTest.java
@@ -50,7 +50,6 @@ public class RecruitmentApplicantTest {
         databaseCleanUp.clear();
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
         populator.addScript(new ClassPathResource("data.sql"));
-        populator.addScript(new ClassPathResource("test-recruitment-applicant.sql"));
         populator.execute(dataSource);
     }
 

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
@@ -1,0 +1,23 @@
+package synk.meeteam.domain.recruitment.recruitment_comment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+
+public class RecruitmentCommentEntityTest {
+
+    @Test
+    void 소프트삭제_성공() {
+        // given
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("댓글입니다.")
+                .isDeleted(false)
+                .build();
+
+        // when
+        comment.softDelete();
+
+        // then
+        Assertions.assertThat(comment.isDeleted()).isEqualTo(true);
+    }
+}

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
@@ -9,13 +9,15 @@ public class RecruitmentCommentEntityTest {
     @Test
     void 소프트삭제_성공() {
         // given
+        Long userId = 1L;
         RecruitmentComment comment = RecruitmentComment.builder()
                 .content("댓글입니다.")
                 .isDeleted(false)
                 .build();
+        comment.setCreatedBy(userId);
 
         // when
-        comment.softDelete();
+        comment.softDelete(userId);
 
         // then
         Assertions.assertThat(comment.isDeleted()).isEqualTo(true);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
@@ -171,7 +171,7 @@ public class RecruitmentCommentServiceTest {
         doReturn(parentComment).when(recruitmentCommentRepository)
                 .findLatestGroupOrderOrElseThrow(recruitmentPost, groupNumber);
         doReturn(Optional.of(parentComment)).when(recruitmentCommentRepository)
-                .findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrder(any(), anyLong());
+                .findFirstByRecruitmentPostAndGroupNumberOrderByGroupOrderDesc(any(), anyLong());
 
         // when
         RecruitmentComment savedRecruitmentComment = recruitmentCommentService.registerRecruitmentComment(childComment);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
@@ -3,7 +3,9 @@ package synk.meeteam.domain.recruitment.recruitment_comment;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_USER;
 
 import java.util.List;
 import java.util.Optional;
@@ -265,6 +267,94 @@ public class RecruitmentCommentServiceTest {
         Assertions.assertThatThrownBy(() -> recruitmentCommentService.registerRecruitmentComment(childComment))
                 .isInstanceOf(RecruitmentCommentException.class)
                 .hasMessageContaining(INVALID_COMMENT.message());
+    }
+
+    @Test
+    void 댓글삭제_성공_대댓글이있는경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        Long userId = 1L;
+        Long commentId = 1L;
+        long groupNumber = 1;
+        long groupOrder = 1;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        RecruitmentComment childComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(false)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder + 1)
+                .build();
+
+        parentComment.setCreatedBy(userId);
+        doReturn(parentComment).when(recruitmentCommentRepository).findByIdOrElseThrow(any());
+        doReturn(childComment).when(recruitmentCommentRepository).findLatestGroupOrderOrElseThrow(any(), anyLong());
+
+        // when, then
+        recruitmentCommentService.deleteComment(commentId, userId, recruitmentPost);
+    }
+
+    @Test
+    void 댓글삭제_예외발생_존재하지않은댓글경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        Long userId = 1L;
+        Long commentId = 1L;
+        long groupNumber = 1;
+        long groupOrder = 1;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        parentComment.setCreatedBy(userId);
+        doThrow(new RecruitmentCommentException(INVALID_COMMENT)).when(recruitmentCommentRepository)
+                .findByIdOrElseThrow(any());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentService.deleteComment(commentId, userId, recruitmentPost))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_COMMENT.message());
+
+    }
+
+    @Test
+    void 댓글삭제_예외발생_댓글작성자가아닌경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        Long userId = 1L;
+        Long commentId = 1L;
+        long groupNumber = 1;
+        long groupOrder = 1;
+
+        RecruitmentComment parentComment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        parentComment.setCreatedBy(0L);
+        doReturn(parentComment).when(recruitmentCommentRepository).findByIdOrElseThrow(any());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentCommentService.deleteComment(commentId, userId, recruitmentPost))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_USER.message());
+
     }
 
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostTest.java
@@ -3,6 +3,7 @@ package synk.meeteam.domain.recruitment.recruitment_post;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_USER;
 import static synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture.TITLE_EXCEED_40;
 import static synk.meeteam.domain.recruitment.recruitment_role.exception.RecruitmentRoleExceptionType.INVALID_RECRUITMENT_ROLE_ID;
 import static synk.meeteam.global.common.exception.GlobalExceptionType.INVALID_INPUT_VALUE;
@@ -37,6 +38,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruit
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CourseTagDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.DeleteCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.RecruitmentRoleDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
@@ -58,6 +60,9 @@ public class RecruitmentPostTest {
     private String refreshHeader;
 
     private String TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInBsYXRmb3JtSWQiOiJEaTdsQ2hNR3hqWlZUYWk2ZDc2SG8xWUxEVV94TDh0bDFDZmRQTVY1U1FNIiwicGxhdGZvcm1UeXBlIjoiTkFWRVIiLCJpYXQiOjE3MDg1OTkyMTMsImV4cCI6MTgxNjU5OTIxM30.C9Rt8t2dM_9pmUIwyMiRwi2kZSXAFVJnjAPj2rTbQtw";
+
+    private String TOKEN_OTHER = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInBsYXRmb3JtSWQiOiJEaTdsQ2hNR3hqWlZUYWk2ZDc2SG8xWUxEVV94TDh0bDFDZmRQTVY1U1ExIiwicGxhdGZvcm1UeXBlIjoiTkFWRVIiLCJpYXQiOjE3MDg1OTkyMTMsImV4cCI6MTgxNjU5OTIxM30.ujVS6-qGhaOYJv0aPet3tgcc5iN93-k0Kv9w1rETFpA";
+
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -332,6 +337,43 @@ public class RecruitmentPostTest {
         // then
         assertEquals(HttpStatus.BAD_REQUEST, twiceResponseEntity.getStatusCode());
         assertEquals(INVALID_COMMENT.name(), twiceResponseEntity.getBody().getName());
+    }
+
+    @Test
+    void 댓글삭제_예외발생_존재하지않은댓글경우() {
+        // given
+        Long postId = 1L;
+        Long commentId = 0L;
+        DeleteCommentRequestDto requestDto = new DeleteCommentRequestDto(commentId);
+        HttpEntity<DeleteCommentRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
+
+        // when
+        String url = RECRUITMENT_URL + "/" + postId.toString() + "/comment";
+        ResponseEntity<ExceptionResponse> ResponseEntity = restTemplate.exchange(url, HttpMethod.DELETE, requestEntity,
+                ExceptionResponse.class);
+
+        // then
+        assertEquals(HttpStatus.BAD_REQUEST, ResponseEntity.getStatusCode());
+        assertEquals(INVALID_COMMENT.name(), ResponseEntity.getBody().getName());
+    }
+
+    @Test
+    void 댓글삭제_예외발생_댓글작성자가아닌경우() {
+        // given
+        Long postId = 1L;
+        Long commentId = 1L;
+        headers.set(accessHeader, TOKEN_OTHER);
+        DeleteCommentRequestDto requestDto = new DeleteCommentRequestDto(commentId);
+        HttpEntity<DeleteCommentRequestDto> requestEntity = new HttpEntity<>(requestDto, headers);
+
+        // when
+        String url = RECRUITMENT_URL + "/" + postId.toString() + "/comment";
+        ResponseEntity<ExceptionResponse> ResponseEntity = restTemplate.exchange(url, HttpMethod.DELETE, requestEntity,
+                ExceptionResponse.class);
+
+        // then
+        assertEquals(HttpStatus.BAD_REQUEST, ResponseEntity.getStatusCode());
+        assertEquals(INVALID_USER.name(), ResponseEntity.getBody().getName());
     }
 
     ///////// Dto 생성 로직 /////////


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #159 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
-댓글 삭제 API 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="900" alt="스크린샷 2024-04-02 오후 9 11 33" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/dce36ea7-52f2-4d64-ba58-df74a07b95c8">


### 삭제 후 로직 실행
<img width="793" alt="스크린샷 2024-04-02 오후 10 27 23" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/485c4972-05c1-4d48-93af-d48d8298c8e9">



## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 조회 로직도 같이 수정했습니다!