### PR TITLE
[FEAT] 내 포트폴리오 목록 조회 API

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/GetProfilePortfolioDto.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/GetProfilePortfolioDto.java
@@ -1,21 +1,40 @@
 package synk.meeteam.domain.portfolio.portfolio.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public record GetProfilePortfolioDto(
-        @Schema(description = "포트폴리오 id", example = "1")
-        Long id,
-        @Schema(description = "제목", example = "Meeteam")
-        String title,
-        @Schema(description = "메인 커버이미지 url", example = "https://~~")
-        String mainImageUrl,
-        @Schema(description = "분야", example = "개발")
-        String field,
-        @Schema(description = "역할", example = "백엔드 개발자")
-        String role,
-        @Schema(description = "핀여부", example = "true")
-        Boolean isPinned,
-        @Schema(description = "핀순서", example = "1")
-        Long pinOrder
-) {
+@Data
+@NoArgsConstructor
+public class GetProfilePortfolioDto {
+    @Schema(description = "포트폴리오 id", example = "1")
+    private Long id;
+    @Schema(description = "제목", example = "Meeteam")
+    private String title;
+    @Schema(description = "메인 커버이미지 url", example = "https://~~")
+    private String mainImageUrl;
+    @Schema(description = "분야", example = "개발")
+    private String field;
+    @Schema(description = "역할", example = "백엔드 개발자")
+    private String role;
+    @Schema(description = "핀여부", example = "true")
+    private boolean isPinned;
+    @Schema(description = "핀순서", example = "1")
+    private int pinOrder;
+
+    @Builder
+    @QueryProjection
+    public GetProfilePortfolioDto(Long id, String title, String mainImageUrl, String field, String role,
+                                  boolean isPinned,
+                                  int pinOrder) {
+        this.id = id;
+        this.title = title;
+        this.mainImageUrl = mainImageUrl;
+        this.field = field;
+        this.role = role;
+        this.isPinned = isPinned;
+        this.pinOrder = pinOrder;
+    }
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/response/GetUserPortfolioResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/response/GetUserPortfolioResponseDto.java
@@ -2,11 +2,11 @@ package synk.meeteam.domain.portfolio.portfolio.dto.response;
 
 import java.util.List;
 import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
-import synk.meeteam.global.dto.PageInfo;
+import synk.meeteam.global.dto.SliceInfo;
 
 public record GetUserPortfolioResponseDto(
         List<GetProfilePortfolioDto> portfolios,
-        PageInfo pageInfo
+        SliceInfo pageInfo
 ) {
 
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/PortfolioMapper.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/PortfolioMapper.java
@@ -23,5 +23,6 @@ public interface PortfolioMapper {
 
     @Mapping(target = "field", qualifiedByName = "toField")
     @Mapping(target = "role", qualifiedByName = "toRole")
+    @Mapping(source = "portfolio.isPin", target = "isPinned")
     GetProfilePortfolioDto toGetProfilePortfolioDto(Portfolio portfolio, String mainImageUrl);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepository.java
@@ -1,0 +1,10 @@
+package synk.meeteam.domain.portfolio.portfolio.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
+import synk.meeteam.domain.user.user.entity.User;
+
+public interface PortfolioCustomRepository {
+    Slice<GetProfilePortfolioDto> findUserPortfoliosByUserOrderByCreatedAtDesc(Pageable pageable, User user);
+}

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
@@ -38,6 +38,8 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
                 .leftJoin(portfolio.field, field)
                 .where(portfolio.isPin.eq(true),
                         portfolio.createdBy.eq(user.getId()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
                 .orderBy(portfolio.createdAt.desc())
                 .fetch();
         return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
@@ -1,0 +1,53 @@
+package synk.meeteam.domain.portfolio.portfolio.repository;
+
+import static synk.meeteam.domain.common.field.entity.QField.field;
+import static synk.meeteam.domain.common.role.entity.QRole.role;
+import static synk.meeteam.domain.portfolio.portfolio.entity.QPortfolio.portfolio;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
+import synk.meeteam.domain.portfolio.portfolio.dto.QGetProfilePortfolioDto;
+import synk.meeteam.domain.user.user.entity.User;
+
+@Repository
+@RequiredArgsConstructor
+public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<GetProfilePortfolioDto> findUserPortfoliosByUserOrderByCreatedAtDesc(Pageable pageable, User user) {
+        List<GetProfilePortfolioDto> contents = queryFactory
+                .select(new QGetProfilePortfolioDto(
+                        portfolio.id,
+                        portfolio.title,
+                        portfolio.mainImageFileName,
+                        portfolio.field.name,
+                        portfolio.role.name,
+                        portfolio.isPin,
+                        portfolio.pinOrder
+                ))
+                .from(portfolio)
+                .leftJoin(portfolio.role, role)
+                .leftJoin(portfolio.field, field)
+                .where(portfolio.isPin.eq(true),
+                        portfolio.createdBy.eq(user.getId()))
+                .orderBy(portfolio.createdAt.desc())
+                .fetch();
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<GetProfilePortfolioDto> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -4,10 +4,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 
-public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, PortfolioCustomRepository {
     List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(Long id);
 
     List<Portfolio> findAllByIdInAndCreatedByOrderByProceedStartAsc(List<Long> ids, Long id);
 
-    List<Portfolio> findAllByCreatedByOrderByProceedStartAsc(Long id);
+    List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(Long id);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
@@ -6,5 +6,5 @@ import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 public interface PortfolioService {
     List<Portfolio> changePinPortfoliosByIds(Long id, List<Long> portfolioIds);
 
-    List<Portfolio> getUserPortfolio(Long userId);
+    List<Portfolio> getUserPinPortfolio(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
@@ -1,10 +1,14 @@
 package synk.meeteam.domain.portfolio.portfolio.service;
 
 import java.util.List;
+import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
+import synk.meeteam.domain.user.user.entity.User;
 
 public interface PortfolioService {
     List<Portfolio> changePinPortfoliosByIds(Long id, List<Long> portfolioIds);
 
     List<Portfolio> getUserPinPortfolio(Long userId);
+
+    GetUserPortfolioResponseDto getUserAllPortfolio(int page, int size, User user);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
@@ -10,5 +10,5 @@ public interface PortfolioService {
 
     List<Portfolio> getUserPinPortfolio(Long userId);
 
-    GetUserPortfolioResponseDto getUserAllPortfolio(int page, int size, User user);
+    GetUserPortfolioResponseDto getMyAllPortfolio(int page, int size, User user);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -39,7 +39,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     }
 
     @Override
-    public List<Portfolio> getUserPortfolio(Long userId) {
-        return portfolioRepository.findAllByCreatedByOrderByProceedStartAsc(userId);
+    public List<Portfolio> getUserPinPortfolio(Long userId) {
+        return portfolioRepository.findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(userId);
     }
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -51,7 +51,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     }
 
     @Override
-    public GetUserPortfolioResponseDto getUserAllPortfolio(int page, int size, User user) {
+    public GetUserPortfolioResponseDto getMyAllPortfolio(int page, int size, User user) {
         int pageNumber = page - 1;
         Pageable pageable = PageRequest.of(pageNumber, size);
         Slice<GetProfilePortfolioDto> userPortfolioDtos = portfolioRepository.findUserPortfoliosByUserOrderByCreatedAtDesc(

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -4,11 +4,18 @@ import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExcepti
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
+import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
 import synk.meeteam.domain.portfolio.portfolio.repository.PortfolioRepository;
+import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.global.dto.SliceInfo;
 
 @Service
 @RequiredArgsConstructor
@@ -41,5 +48,15 @@ public class PortfolioServiceImpl implements PortfolioService {
     @Override
     public List<Portfolio> getUserPinPortfolio(Long userId) {
         return portfolioRepository.findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(userId);
+    }
+
+    @Override
+    public GetUserPortfolioResponseDto getUserAllPortfolio(int page, int size, User user) {
+        int pageNumber = page - 1;
+        Pageable pageable = PageRequest.of(pageNumber, size);
+        Slice<GetProfilePortfolioDto> userPortfolioDtos = portfolioRepository.findUserPortfoliosByUserOrderByCreatedAtDesc(
+                pageable, user);
+        SliceInfo pageInfo = new SliceInfo(page, size, userPortfolioDtos.hasNext());
+        return new GetUserPortfolioResponseDto(userPortfolioDtos.getContent(), pageInfo);
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
@@ -63,6 +63,6 @@ public interface UserApi {
     @Operation(summary = "내 포트폴리오 목록 조회 API")
     @SecurityRequirement(name = "Authorization")
     ResponseEntity<GetUserPortfolioResponseDto> getUserPortfolio(@AuthUser User user,
-                                                                 @RequestParam Long size,
-                                                                 @RequestParam Long page);
+                                                                 @RequestParam(name = "page", defaultValue = "1") int page,
+                                                                 @RequestParam(name = "size", defaultValue = "12") int size);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -19,7 +19,7 @@ import synk.meeteam.domain.user.user.dto.response.GetProfileResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.ProfileFacade;
 import synk.meeteam.domain.user.user.service.UserService;
-import synk.meeteam.global.dto.PageInfo;
+import synk.meeteam.global.dto.SliceInfo;
 import synk.meeteam.global.util.Encryption;
 import synk.meeteam.security.AuthUser;
 
@@ -85,7 +85,7 @@ public class UserController implements UserApi {
                                         true,
                                         2L)
                         ),
-                        new PageInfo(1, 10, 30L, 3)
+                        new SliceInfo(1, 10, false)
                 )
         );
     }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -1,7 +1,6 @@
 package synk.meeteam.domain.user.user.api;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,15 +10,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
 import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
+import synk.meeteam.domain.portfolio.portfolio.service.PortfolioService;
 import synk.meeteam.domain.user.user.dto.request.UpdateProfileRequestDto;
 import synk.meeteam.domain.user.user.dto.response.CheckDuplicateNicknameResponseDto;
 import synk.meeteam.domain.user.user.dto.response.GetProfileResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.ProfileFacade;
 import synk.meeteam.domain.user.user.service.UserService;
-import synk.meeteam.global.dto.SliceInfo;
 import synk.meeteam.global.util.Encryption;
 import synk.meeteam.security.AuthUser;
 
@@ -29,6 +27,7 @@ import synk.meeteam.security.AuthUser;
 public class UserController implements UserApi {
 
     private final UserService userService;
+    private final PortfolioService portfolioService;
     private final ProfileFacade profileFacade;
 
     @Override
@@ -65,28 +64,8 @@ public class UserController implements UserApi {
     @Override
     @GetMapping("/portfolios")
     public ResponseEntity<GetUserPortfolioResponseDto> getUserPortfolio(
-            @AuthUser User user, @RequestParam(name = "size", defaultValue = "10") Long size,
-            @RequestParam(name = "page", defaultValue = "1") Long page) {
-        return ResponseEntity.ok(
-                new GetUserPortfolioResponseDto(
-                        List.of(
-                                new GetProfilePortfolioDto(1L,
-                                        "타이틀1",
-                                        "https://image.png",
-                                        "개발",
-                                        "백엔드",
-                                        true,
-                                        1),
-                                new GetProfilePortfolioDto(2L,
-                                        "타이틀2",
-                                        "https://image.png",
-                                        "개발",
-                                        "프론트",
-                                        true,
-                                        2)
-                        ),
-                        new SliceInfo(1, 10, false)
-                )
-        );
+            @AuthUser User user, @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "12") int size) {
+        return ResponseEntity.ok(portfolioService.getMyAllPortfolio(page, size, user));
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -76,14 +76,14 @@ public class UserController implements UserApi {
                                         "개발",
                                         "백엔드",
                                         true,
-                                        1L),
+                                        1),
                                 new GetProfilePortfolioDto(2L,
                                         "타이틀2",
                                         "https://image.png",
                                         "개발",
                                         "프론트",
                                         true,
-                                        2L)
+                                        2)
                         ),
                         new SliceInfo(1, 10, false)
                 )

--- a/src/main/java/synk/meeteam/domain/user/user/service/ProfileFacade.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/ProfileFacade.java
@@ -88,7 +88,7 @@ public class ProfileFacade {
     }
 
     private List<GetProfilePortfolioDto> getProfilePortfolios(Long userId, String encryptedId) {
-        List<Portfolio> portfolios = portfolioService.getUserPortfolio(userId);
+        List<Portfolio> portfolios = portfolioService.getUserPinPortfolio(userId);
 
         return portfolios.stream().map((portfolio) -> {
             String imageUrl = s3Service.createPreSignedGetUrl(

--- a/src/main/java/synk/meeteam/global/dto/SliceInfo.java
+++ b/src/main/java/synk/meeteam/global/dto/SliceInfo.java
@@ -1,0 +1,13 @@
+package synk.meeteam.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SliceInfo(
+        @Schema(description = "현재 페이지", example = "1")
+        int page,
+        @Schema(description = "개수", example = "10")
+        int size,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNextPage
+) {
+}

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
@@ -2,9 +2,15 @@ package synk.meeteam.domain.portfolio.portfolio;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
+import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
+import synk.meeteam.global.dto.SliceInfo;
 
 public class PortfolioFixture {
     public static List<Portfolio> createPortfolioFixtures_1_2() {
@@ -38,5 +44,26 @@ public class PortfolioFixture {
                 .build();
         portfolio.setCreatedBy(createdBy);
         return portfolio;
+    }
+
+    public static Slice<GetProfilePortfolioDto> createSlicePortfolioDtos() {
+        return new SliceImpl<>(
+                List.of(
+                        new GetProfilePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1),
+                        new GetProfilePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2)
+                ),
+                PageRequest.of(1, 12),
+                false
+        );
+    }
+
+    public static GetUserPortfolioResponseDto createUserAllPortfolios() {
+        return new GetUserPortfolioResponseDto(
+                List.of(
+                        new GetProfilePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1),
+                        new GetProfilePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2)
+                ),
+                new SliceInfo(1, 12, false)
+        );
     }
 }

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -8,13 +8,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.field.repository.FieldRepository;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.common.role.repository.RoleRepository;
+import synk.meeteam.domain.portfolio.portfolio.dto.GetProfilePortfolioDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio.repository.PortfolioRepository;
+import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.repository.UserRepository;
 
 @DataJpaTest
@@ -41,7 +45,8 @@ public class PortfolioRepositoryTest {
         List<Portfolio> portfolios = List.of(
                 PortfolioFixture.createUserPortfolio("타이틀1", true, 1, 1L, LocalDate.of(2024, 1, 2), role, field),
                 PortfolioFixture.createUserPortfolio("타이틀2", true, 2, 1L, LocalDate.of(2024, 1, 3), role, field),
-                PortfolioFixture.createUserPortfolio("타이틀3", false, 3, 1L, LocalDate.of(2024, 1, 4), role, field)
+                PortfolioFixture.createUserPortfolio("타이틀3", false, 3, 1L, LocalDate.of(2024, 1, 4), role, field),
+                PortfolioFixture.createUserPortfolio("타이틀4", true, 1, 2L, LocalDate.of(2024, 1, 4), role, field)
         );
         portfolioRepository.saveAllAndFlush(portfolios);
     }
@@ -66,5 +71,18 @@ public class PortfolioRepositoryTest {
                         LocalDate.of(2024, 1, 3)
                 );
 
+    }
+
+    @Test
+    void 유저포트폴리오조회_조회성공() {
+        //given
+        User user = userRepository.findById(1L).get();
+        //when
+        Slice<GetProfilePortfolioDto> userPortfolios = portfolioRepository.findUserPortfoliosByUserOrderByCreatedAtDesc(
+                PageRequest.of(1, 12), user);
+        //then
+        assertThat(userPortfolios.hasNext()).isEqualTo(false);
+        assertThat(userPortfolios.getSize()).isEqualTo(12);
+        assertThat(userPortfolios.getContent()).extracting("title").containsExactly("타이틀2", "타이틀1");
     }
 }

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -55,16 +55,15 @@ public class PortfolioRepositoryTest {
     }
 
     @Test
-    void 유저포트폴리오조회_조회성공() {
+    void 유저핀포트폴리오조회_조회성공() {
         //when
-        List<Portfolio> userPortfolios = portfolioRepository.findAllByCreatedByOrderByProceedStartAsc(1L);
+        List<Portfolio> userPortfolios = portfolioRepository.findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(1L);
         //then
-        assertThat(userPortfolios).extracting("title").containsExactly("타이틀1", "타이틀2", "타이틀3");
+        assertThat(userPortfolios).extracting("title").containsExactly("타이틀1", "타이틀2");
         assertThat(userPortfolios).extracting("proceedStart")
                 .containsExactly(
                         LocalDate.of(2024, 1, 2),
-                        LocalDate.of(2024, 1, 3),
-                        LocalDate.of(2024, 1, 4)
+                        LocalDate.of(2024, 1, 3)
                 );
 
     }

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -89,7 +89,7 @@ public class PortfolioServiceTest {
         doReturn(PortfolioFixture.createSlicePortfolioDtos()).when(portfolioRepository)
                 .findUserPortfoliosByUserOrderByCreatedAtDesc(eq(PageRequest.of(0, 12)), any());
         //when
-        GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getUserAllPortfolio(1, 12,
+        GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getMyAllPortfolio(1, 12,
                 User.builder().build());
 
         //then

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -2,6 +2,7 @@ package synk.meeteam.domain.portfolio.portfolio;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -14,11 +15,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
 import synk.meeteam.domain.portfolio.portfolio.repository.PortfolioRepository;
 import synk.meeteam.domain.portfolio.portfolio.service.PortfolioService;
 import synk.meeteam.domain.portfolio.portfolio.service.PortfolioServiceImpl;
+import synk.meeteam.domain.user.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
 public class PortfolioServiceTest {
@@ -79,4 +83,19 @@ public class PortfolioServiceTest {
         assertThat(userPortfolio).extracting("title").containsExactly("타이틀1", "타이틀2");
     }
 
+    @Test
+    void 내포트폴리오목록조회_목록조회성공() {
+        //given
+        doReturn(PortfolioFixture.createSlicePortfolioDtos()).when(portfolioRepository)
+                .findUserPortfoliosByUserOrderByCreatedAtDesc(eq(PageRequest.of(0, 12)), any());
+        //when
+        GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getUserAllPortfolio(1, 12,
+                User.builder().build());
+
+        //then
+        assertThat(userAllPortfolios.portfolios()).extracting("title").containsExactly("타이틀1", "타이틀2");
+        assertThat(userAllPortfolios.pageInfo().page()).isEqualTo(1);
+        assertThat(userAllPortfolios.pageInfo().size()).isEqualTo(12);
+        assertThat(userAllPortfolios.pageInfo().hasNextPage()).isEqualTo(false);
+    }
 }

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -72,9 +72,9 @@ public class PortfolioServiceTest {
     void 포트폴리오목록조회_목록조회성공() {
         //given
         doReturn(PortfolioFixture.createPortfolioFixtures_1_2()).when(portfolioRepository)
-                .findAllByCreatedByOrderByProceedStartAsc(anyLong());
+                .findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(anyLong());
         //when
-        List<Portfolio> userPortfolio = portfolioService.getUserPortfolio(anyLong());
+        List<Portfolio> userPortfolio = portfolioService.getUserPinPortfolio(anyLong());
         //then
         assertThat(userPortfolio).extracting("title").containsExactly("타이틀1", "타이틀2");
     }

--- a/src/test/java/synk/meeteam/domain/user/user/UserControllerTest.java
+++ b/src/test/java/synk/meeteam/domain/user/user/UserControllerTest.java
@@ -1,5 +1,6 @@
 package synk.meeteam.domain.user.user;
 
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -25,6 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import synk.meeteam.domain.portfolio.portfolio.PortfolioFixture;
+import synk.meeteam.domain.portfolio.portfolio.service.PortfolioService;
 import synk.meeteam.domain.user.user.api.UserController;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.ProfileFacade;
@@ -41,6 +44,9 @@ public class UserControllerTest {
 
     @Mock
     ProfileFacade profileFacade;
+
+    @Mock
+    PortfolioService portfolioService;
     private MockMvc mockMvc;
     private Gson gson;
 
@@ -113,6 +119,28 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.universityEmail.content").value("minji@kw.ac.kr"))
                 .andExpect(jsonPath("$.awards[0].title").value("공공데이터 공모전"))
                 .andExpect(jsonPath("$.links[1].description").value("Github"));
+    }
+
+    @Test
+    void 내포트폴리오조회_조회성공() throws Exception {
+        //given
+        final String url = "/user/portfolios";
+        doReturn(PortfolioFixture.createUserAllPortfolios()).when(portfolioService)
+                .getMyAllPortfolio(eq(1), eq(12), any());
+        //when
+        final ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get(url)
+                        .param("page", "1")
+        );
+        //then
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.pageInfo.page").value(1),
+                jsonPath("$.pageInfo.size").value(12),
+                jsonPath("$.pageInfo.hasNextPage").value(false),
+                jsonPath("$.portfolios").isNotEmpty(),
+                jsonPath("$.portfolios.*.title", hasItems("타이틀1", "타이틀2"))
+        );
     }
 
 }

--- a/src/test/java/synk/meeteam/domain/user/user/UserFixture.java
+++ b/src/test/java/synk/meeteam/domain/user/user/UserFixture.java
@@ -81,7 +81,7 @@ public class UserFixture {
                 4.3,
                 2019,
                 List.of(
-                        new GetProfilePortfolioDto(1L, "Meeteam 팀을 만나다", "https://~", "개발", "백엔드개발자", true, 1L)
+                        new GetProfilePortfolioDto(1L, "Meeteam 팀을 만나다", "https://~", "개발", "백엔드개발자", true, 1)
                 ),
                 List.of(
                         new GetProfileUserLinkDto("https://~~", "Link"),


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#166 -> dev
- closed #166 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
내 포트폴리오 목록 조회 API 구현했습니다.
일부 조회 로직 수정하였습니다.
- TODO 이미지 url
  - 현재 이미지 이름만 return 하고 있습니다. 추후 이미지 업로드 구현되면 추가하려고 합니다. 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/1f318876-ba6c-4df0-8ea1-eacc834b1c8e)

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 기능적 분류를 위하여 `Repository`와 `Service`는 `Portfolio`를 `Controller`는 `User`를 이용하였습니다.
- Repository에서 Dto로 조회 후, `Service`에서 Dto 변환(추후 이미지 url 변환 과정 추가예정), `Controller`는 단순 return 합니다.
- `Pageable` 객체를 줄 때, `PageRequest.of` 메소드를 이용하는데 이때 page는 인덱스 개념이어서 1을 빼주는 과정을 `Service`에서 진행합니다.
- `SliceInfo` 레코드 정의하였습니다.