### PR TITLE
[FEAT] 댓글 수정 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,9 @@ dependencies {
 
     // aws
     implementation "software.amazon.awssdk:s3:2.21.0"
+
+    // PATCH 메서드 지원을 위함
+    implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/synk/meeteam/domain/common/role/dto/RoleDto.java
+++ b/src/main/java/synk/meeteam/domain/common/role/dto/RoleDto.java
@@ -12,11 +12,11 @@ public class RoleDto {
     private Long id;
 
     @Schema(description = "역할 이름", example = "백엔드개발자")
-    private String title;
+    private String name;
 
     @QueryProjection
-    public RoleDto(Long id, String title) {
+    public RoleDto(Long id, String name) {
         this.id = id;
-        this.title = title;
+        this.name = name;
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import synk.meeteam.domain.common.role.dto.RoleDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.ApproveApplicantRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.SetLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetRecruitmentRoleStatusResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetRoleDto;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
@@ -55,8 +55,8 @@ public class RecruitmentApplicantController implements RecruitmentApplicantApi {
                         role.getRecruitedCount()))
                 .toList();
 
-        List<RoleDto> roleDtos = applyStatusRecruitmentRoles.stream()
-                .map(role -> new RoleDto(role.getRole().getId(), role.getRole().getName()))
+        List<GetRoleDto> roleDtos = applyStatusRecruitmentRoles.stream()
+                .map(role -> new GetRoleDto(role.getRole().getId(), role.getRole().getName()))
                 .toList();
 
         return ResponseEntity.ok()

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantInfoResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantInfoResponseDto.java
@@ -2,7 +2,6 @@ package synk.meeteam.domain.recruitment.recruitment_applicant.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import synk.meeteam.domain.common.role.dto.RoleDto;
 
 @Schema(name = "GetApplicantInfoResponseDto", description = "신청 정보 조회 Dto")
 public record GetApplicantInfoResponseDto(
@@ -11,6 +10,6 @@ public record GetApplicantInfoResponseDto(
         @Schema(description = "오픈카톡방 링크", example = "https://open.kakao.com/o/gLmqdijg")
         String link,
         List<GetRecruitmentRoleStatusResponseDto> recruitmentStatus,
-        List<RoleDto> roles
+        List<GetRoleDto> roles
 ) {
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetRoleDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetRoleDto.java
@@ -1,0 +1,12 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetRoleDto(
+        @Schema(description = "역할 id", example = "1")
+        Long id,
+
+        @Schema(description = "역할 이름", example = "백엔드개발자")
+        String title
+) {
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/entity/RecruitmentComment.java
@@ -82,6 +82,12 @@ public class RecruitmentComment extends BaseEntity {
         return false;
     }
 
+    public void modifyContent(String content, Long userId) {
+        validateWriter(userId);
+
+        this.content = content;
+    }
+
     public void validateWriter(Long userId) {
         if (!this.getCreatedBy().equals(userId)) {
             throw new RecruitmentCommentException(INVALID_USER);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -92,6 +92,13 @@ public class RecruitmentCommentService {
         return recruitmentCommentRepository.save(recruitmentComment);
     }
 
+    @Transactional
+    public void modifyRecruitmentComment(Long userId, Long commentId, String content) {
+        RecruitmentComment recruitmentComment = recruitmentCommentRepository.findByIdOrElseThrow(commentId);
+
+        recruitmentComment.modifyContent(content, userId);
+    }
+
     private long getNewGroupNumber(RecruitmentPost recruitmentPost) {
         RecruitmentComment recruitmentComment = recruitmentCommentRepository.findFirstByRecruitmentPostOrderByGroupNumberDesc(
                 recruitmentPost).orElse(null);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostApi.java
@@ -19,6 +19,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruit
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.DeleteCommentRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ModifyCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetRecruitmentPostResponseDto;
@@ -164,4 +165,15 @@ public interface RecruitmentPostApi {
     ResponseEntity<Void> deleteComment(@PathVariable("id") Long postId,
                                        @Valid @RequestBody DeleteCommentRequestDto requestDto, @AuthUser User user);
 
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"
+                            , content = {
+                            @Content(mediaType = APPLICATION_JSON_VALUE)
+                    })
+            }
+    )
+    @Operation(summary = "댓글 수정 API", tags = {"comment"})
+    ResponseEntity<Void> modifyComment(@PathVariable("id") Long postId,
+                                       @Valid @RequestBody ModifyCommentRequestDto requestDto, @AuthUser User user);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -38,6 +38,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ApplyRecruit
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateRecruitmentPostRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.DeleteCommentRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_post.dto.request.ModifyCommentRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.CreateRecruitmentPostResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetApplyInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.GetCommentResponseDto;
@@ -256,6 +257,17 @@ public class RecruitmentPostController implements RecruitmentPostApi {
 
         RecruitmentPost recruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
         recruitmentCommentService.deleteComment(requestDto.commentId(), user.getId(), recruitmentPost);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{id}/comment")
+    @Override
+    public ResponseEntity<Void> modifyComment(@PathVariable("id") Long postId,
+                                              @Valid @RequestBody ModifyCommentRequestDto requestDto,
+                                              @AuthUser User user) {
+
+        recruitmentCommentService.modifyRecruitmentComment(user.getId(), requestDto.commentId(), requestDto.content());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/ModifyCommentRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/request/ModifyCommentRequestDto.java
@@ -1,0 +1,17 @@
+package synk.meeteam.domain.recruitment.recruitment_post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "ModifyCommentRequestDto", description = "댓글 수정 요청 Dto")
+public record ModifyCommentRequestDto(
+        @Schema(description = "댓글 id", example = "2")
+        @NotNull
+        Long commentId,
+        @Schema(description = "댓글 내용", example = "저 진짜 하고 싶어요")
+        @NotNull
+        @Size(min = 1, max = 100)
+        String content
+) {
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
@@ -37,8 +37,7 @@ public class RecruitmentRoleService {
 
     @Transactional(readOnly = true)
     public List<AvailableRecruitmentRoleDto> findAvailableRecruitmentRole(Long postId) {
-        return recruitmentRoleRepository.findAvailableRecruitmentRoleByRecruitmentId(
-                postId);
+        return recruitmentRoleRepository.findAvailableRecruitmentRoleByRecruitmentId(postId);
     }
 
     @Transactional

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentEntityTest.java
@@ -1,8 +1,11 @@
 package synk.meeteam.domain.recruitment.recruitment_comment;
 
+import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_USER;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
+import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
 
 public class RecruitmentCommentEntityTest {
 
@@ -21,5 +24,54 @@ public class RecruitmentCommentEntityTest {
 
         // then
         Assertions.assertThat(comment.isDeleted()).isEqualTo(true);
+    }
+
+    @Test
+    void 소프트삭제_예외발생_작성자가아닌경우() {
+        // given
+        Long userId = 1L;
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("댓글입니다.")
+                .isDeleted(false)
+                .build();
+        comment.setCreatedBy(0L);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> comment.softDelete(userId))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_USER.message());
+    }
+
+    @Test
+    void 댓글수정_성공() {
+        // given
+        Long userId = 1L;
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("댓글입니다.")
+                .isDeleted(false)
+                .build();
+        comment.setCreatedBy(userId);
+
+        // when
+        comment.modifyContent("수정내용입니다.", userId);
+
+        // then
+        Assertions.assertThat(comment.getContent()).isEqualTo("수정내용입니다.");
+    }
+
+    @Test
+    void 댓글수정_예외발생_작성자가아닌경우() {
+        // given
+        Long userId = 1L;
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("댓글입니다.")
+                .isDeleted(false)
+                .build();
+        comment.setCreatedBy(0L);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> comment.modifyContent("수정내용입니다.", userId))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_USER.message());
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
@@ -357,4 +357,57 @@ public class RecruitmentCommentServiceTest {
 
     }
 
+    @Test
+    void 댓글수정_성공() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        Long userId = 1L;
+        Long commentId = 1L;
+        long groupNumber = 1;
+        long groupOrder = 1;
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        comment.setCreatedBy(userId);
+
+        doReturn(comment).when(recruitmentCommentRepository).findByIdOrElseThrow(any());
+
+        // when, then
+        recruitmentCommentService.modifyRecruitmentComment(userId, commentId, "수정내용입니다.");
+    }
+
+    @Test
+    void 댓글수정_예외발생_작성자가아닌경우() {
+        // given
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        Long userId = 1L;
+        Long commentId = 1L;
+        long groupNumber = 1;
+        long groupOrder = 1;
+
+        RecruitmentComment comment = RecruitmentComment.builder()
+                .content("저 하고 싶어요")
+                .isParent(true)
+                .recruitmentPost(recruitmentPost)
+                .groupNumber(groupNumber)
+                .groupOrder(groupOrder)
+                .build();
+
+        comment.setCreatedBy(0L);
+
+        doReturn(comment).when(recruitmentCommentRepository).findByIdOrElseThrow(any());
+
+        // when, then
+        Assertions.assertThatThrownBy(
+                        () -> recruitmentCommentService.modifyRecruitmentComment(userId, commentId, "수정내용입니다."))
+                .isInstanceOf(RecruitmentCommentException.class)
+                .hasMessageContaining(INVALID_USER.message());
+    }
+
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #176 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 댓글 수정 API 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="859" alt="스크린샷 2024-04-03 오후 5 13 04" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/d83f5230-10e8-44fe-8f83-00922234d212">
<img width="862" alt="스크린샷 2024-04-03 오후 5 13 10" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/29b82c46-a750-4712-9b29-0f9ae57734b4">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- PATCH 메서드 지원을 위해 의존성 추가했습니다!
- 관련 자료 : https://learnote-dev.com/java/Spring-TestRestTemplate-Patch-%EC%9A%94%EC%B2%AD-%EC%98%A4%EB%A5%98%EB%82%A0-%EB%95%8C/