### PR TITLE
[FEAT] 신청자 승인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,10 @@ dependencies {
 
     // PATCH 메서드 지원을 위함
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
+
+    // 메일 서비스를 위함
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
@@ -17,6 +17,7 @@ import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.Approve
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.SetLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetRecruitmentRoleStatusResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_applicant.facade.RecruitmentApplicantFacade;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
@@ -28,6 +29,8 @@ import synk.meeteam.security.AuthUser;
 @RequiredArgsConstructor
 @RequestMapping("/recruitment/applicant")
 public class RecruitmentApplicantController implements RecruitmentApplicantApi {
+
+    private final RecruitmentApplicantFacade recruitmentApplicantFacade;
 
     private final RecruitmentPostService recruitmentPostService;
     private final RecruitmentRoleService recruitmentRoleService;
@@ -70,6 +73,11 @@ public class RecruitmentApplicantController implements RecruitmentApplicantApi {
                                                  @RequestBody ApproveApplicantRequestDto requestDto,
                                                  @AuthUser User user) {
 
+        // recruitmentPost 의 responseCount + 1
+        // recruitmentRole 의 recruitedCount + 1 (거절의 경우 변화X)
+        // applicant의 enum 상태 변경
+
+        recruitmentApplicantFacade.approveApplicant(postId, user.getId(), requestDto.applicantIds());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitStatus.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitStatus.java
@@ -1,0 +1,8 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RecruitStatus {
+    NONE, APPROVED, REJECTED
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitmentApplicant.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitmentApplicant.java
@@ -38,7 +38,7 @@ public class RecruitmentApplicant extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = LAZY, optional = false)
-    @JoinColumn(name = "recruitment_id")
+    @JoinColumn(name = "recruitment_post_id")
     private RecruitmentPost recruitmentPost;
 
     @ManyToOne(fetch = LAZY, optional = false)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitmentApplicant.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/entity/RecruitmentApplicant.java
@@ -64,11 +64,13 @@ public class RecruitmentApplicant extends BaseTimeEntity {
     private RecruitStatus recruitStatus;
 
     @Builder
-    public RecruitmentApplicant(RecruitmentPost recruitmentPost, User applicant, Role role, String comment) {
+    public RecruitmentApplicant(RecruitmentPost recruitmentPost, User applicant, Role role, String comment,
+                                RecruitStatus recruitStatus) {
         this.recruitmentPost = recruitmentPost;
         this.applicant = applicant;
         this.role = role;
         this.comment = comment;
+        this.recruitStatus = recruitStatus;
     }
 
     public void validateCanApprove(Long userId) {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/exception/RecruitmentApplicantExceptionType.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/exception/RecruitmentApplicantExceptionType.java
@@ -6,7 +6,8 @@ import synk.meeteam.global.common.exception.ExceptionType;
 
 @RequiredArgsConstructor
 public enum RecruitmentApplicantExceptionType implements ExceptionType {
-    ;
+    INVALID_USER(HttpStatus.BAD_REQUEST, "신청자 정보에 접근할 수 없습니다."),
+    ALREADY_PROCESSED_APPLICANT(HttpStatus.BAD_REQUEST, "이미 신청/거절된 신청자입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/exception/RecruitmentApplicantExceptionType.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/exception/RecruitmentApplicantExceptionType.java
@@ -7,7 +7,9 @@ import synk.meeteam.global.common.exception.ExceptionType;
 @RequiredArgsConstructor
 public enum RecruitmentApplicantExceptionType implements ExceptionType {
     INVALID_USER(HttpStatus.BAD_REQUEST, "신청자 정보에 접근할 수 없습니다."),
-    ALREADY_PROCESSED_APPLICANT(HttpStatus.BAD_REQUEST, "이미 신청/거절된 신청자입니다.");
+    ALREADY_PROCESSED_APPLICANT(HttpStatus.BAD_REQUEST, "이미 신청/거절된 신청자입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 신청자 처리 요청입니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
@@ -1,6 +1,5 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant.facade;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.service.RecruitmentApplicantService;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
-import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
 import synk.meeteam.domain.recruitment.recruitment_role.service.RecruitmentRoleService;
 
 @Service
@@ -24,27 +22,12 @@ public class RecruitmentApplicantFacade {
     public void approveApplicant(Long postId, Long userId, List<Long> applicantIds) {
 
         List<RecruitmentApplicant> applicants = recruitmentApplicantService.getAllApplicants(applicantIds);
+        recruitmentApplicantService.approveApplicants(applicants, applicantIds, userId);
 
-        recruitmentApplicantService.approveApplicants(applicantIds, applicants, userId);
+        List<Long> roleIds = recruitmentApplicantService.getRoleIds(applicants);
+        Map<Long, Long> recruitedCounts = recruitmentApplicantService.getRecruitedCounts(applicants);
+
         recruitmentPostService.incrementResponseCount(postId, userId, applicantIds.size());
-
-        Map<Long, Long> recruitedRoles = new HashMap<>();
-        List<Long> roleIds = applicants.stream()
-                .map(applicant -> {
-                    recruitedRoles.putIfAbsent(applicant.getRole().getId(), 0L);
-
-                    recruitedRoles.put(applicant.getRole().getId(),
-                            recruitedRoles.get(applicant.getRole().getId()) + 1);
-                    return applicant.getRole().getId();
-                }).toList();
-
-        List<RecruitmentRole> recruitmentRoles = recruitmentRoleService.findAllByRecruitmentAndRoles(postId,
-                roleIds);
-
-        recruitmentRoles.stream()
-                .forEach(recruitmentRole -> {
-                    long recruitedCount = recruitedRoles.get(recruitmentRole.getRole().getId());
-                    recruitmentRole.incrementRecruitedCount(recruitedCount);
-                });
+        recruitmentRoleService.incrementRecruitedCount(postId, roleIds, recruitedCounts);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
@@ -28,6 +28,6 @@ public class RecruitmentApplicantFacade {
         Map<Long, Long> recruitedCounts = recruitmentApplicantService.getRecruitedCounts(applicants);
 
         recruitmentPostService.incrementResponseCount(postId, userId, applicantIds.size());
-        recruitmentRoleService.incrementRecruitedCount(postId, roleIds, recruitedCounts);
+        recruitmentRoleService.incrementRecruitedCount(postId, userId, roleIds, recruitedCounts);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
@@ -1,0 +1,50 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.facade;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.recruitment.recruitment_applicant.service.RecruitmentApplicantService;
+import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
+import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
+import synk.meeteam.domain.recruitment.recruitment_role.service.RecruitmentRoleService;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentApplicantFacade {
+
+    private final RecruitmentPostService recruitmentPostService;
+    private final RecruitmentRoleService recruitmentRoleService;
+    private final RecruitmentApplicantService recruitmentApplicantService;
+
+    @Transactional
+    public void approveApplicant(Long postId, Long userId, List<Long> applicantIds) {
+
+        List<RecruitmentApplicant> applicants = recruitmentApplicantService.getAllApplicants(applicantIds);
+
+        recruitmentApplicantService.approveApplicants(applicantIds, applicants, userId);
+        recruitmentPostService.incrementResponseCount(postId, userId, applicantIds.size());
+
+        Map<Long, Long> recruitedRoles = new HashMap<>();
+        List<Long> roleIds = applicants.stream()
+                .map(applicant -> {
+                    recruitedRoles.putIfAbsent(applicant.getRole().getId(), 0L);
+
+                    recruitedRoles.put(applicant.getRole().getId(),
+                            recruitedRoles.get(applicant.getRole().getId()) + 1);
+                    return applicant.getRole().getId();
+                }).toList();
+
+        List<RecruitmentRole> recruitmentRoles = recruitmentRoleService.findAllByRecruitmentAndRoles(postId,
+                roleIds);
+
+        recruitmentRoles.stream()
+                .forEach(recruitmentRole -> {
+                    long recruitedCount = recruitedRoles.get(recruitmentRole.getRole().getId());
+                    recruitmentRole.incrementRecruitedCount(recruitedCount);
+                });
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
@@ -7,8 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.service.RecruitmentApplicantService;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
 import synk.meeteam.domain.recruitment.recruitment_role.service.RecruitmentRoleService;
+import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.domain.user.user.service.UserService;
 import synk.meeteam.infra.mail.MailService;
 
 @Service
@@ -18,6 +21,7 @@ public class RecruitmentApplicantFacade {
     private final RecruitmentPostService recruitmentPostService;
     private final RecruitmentRoleService recruitmentRoleService;
     private final RecruitmentApplicantService recruitmentApplicantService;
+    private final UserService userService;
 
     private final MailService mailService;
 
@@ -33,6 +37,8 @@ public class RecruitmentApplicantFacade {
         recruitmentPostService.incrementResponseCount(postId, userId, applicantIds.size());
         recruitmentRoleService.incrementRecruitedCount(postId, userId, roleIds, recruitedCounts);
 
-        mailService.sendApproveMails(postId, applicants);
+        RecruitmentPost recruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
+        User user = userService.findById(recruitmentPost.getCreatedBy());
+        mailService.sendApproveMails(postId, applicants, user.getName());
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/facade/RecruitmentApplicantFacade.java
@@ -9,6 +9,7 @@ import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentA
 import synk.meeteam.domain.recruitment.recruitment_applicant.service.RecruitmentApplicantService;
 import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
 import synk.meeteam.domain.recruitment.recruitment_role.service.RecruitmentRoleService;
+import synk.meeteam.infra.mail.MailService;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,8 @@ public class RecruitmentApplicantFacade {
     private final RecruitmentPostService recruitmentPostService;
     private final RecruitmentRoleService recruitmentRoleService;
     private final RecruitmentApplicantService recruitmentApplicantService;
+
+    private final MailService mailService;
 
     @Transactional
     public void approveApplicant(Long postId, Long userId, List<Long> applicantIds) {
@@ -29,5 +32,7 @@ public class RecruitmentApplicantFacade {
 
         recruitmentPostService.incrementResponseCount(postId, userId, applicantIds.size());
         recruitmentRoleService.incrementRecruitedCount(postId, userId, roleIds, recruitedCounts);
+
+        mailService.sendApproveMails(postId, applicants);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepository.java
@@ -1,0 +1,7 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.repository;
+
+import java.util.List;
+
+public interface RecruitmentApplicantCustomRepository {
+    long bulkApprove(List<Long> applicantIds);
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
@@ -1,0 +1,24 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.repository;
+
+import static synk.meeteam.domain.recruitment.recruitment_applicant.entity.QRecruitmentApplicant.recruitmentApplicant;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitmentApplicantCustomRepositoryImpl implements RecruitmentApplicantCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public long bulkApprove(List<Long> applicantIds) {
+        return jpaQueryFactory.update(recruitmentApplicant)
+                .where(recruitmentApplicant.id.in(applicantIds))
+                .set(recruitmentApplicant.recruitStatus, RecruitStatus.APPROVED)
+                .execute();
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -10,5 +10,5 @@ public interface RecruitmentApplicantRepository extends JpaRepository<Recruitmen
         RecruitmentApplicantCustomRepository {
 
     @Query("SELECT a FROM RecruitmentApplicant a JOIN FETCH a.recruitmentPost WHERE a.id IN :ids")
-    List<RecruitmentApplicant> findAllById(@Param("ids") List<Long> applicantIds);
+    List<RecruitmentApplicant> findAllInApplicantId(@Param("ids") List<Long> applicantIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -1,7 +1,14 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 
-public interface RecruitmentApplicantRepository extends JpaRepository<RecruitmentApplicant, Long> {
+public interface RecruitmentApplicantRepository extends JpaRepository<RecruitmentApplicant, Long>,
+        RecruitmentApplicantCustomRepository {
+
+    @Query("SELECT a FROM RecruitmentApplicant a JOIN FETCH a.recruitmentPost WHERE a.id IN :ids")
+    List<RecruitmentApplicant> findAllById(@Param("ids") List<Long> applicantIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
@@ -2,7 +2,9 @@ package synk.meeteam.domain.recruitment.recruitment_applicant.service;
 
 import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantExceptionType.INVALID_REQUEST;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +27,28 @@ public class RecruitmentApplicantService {
         return recruitmentApplicantRepository.findAllById(applicantIds);
     }
 
+    @Transactional(readOnly = true)
+    public List<Long> getRoleIds(List<RecruitmentApplicant> approvedApplicants) {
+        return approvedApplicants.stream()
+                .map(applicant -> applicant.getRole().getId()).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Long> getRecruitedCounts(List<RecruitmentApplicant> approvedApplicants) {
+        Map<Long, Long> recruitedRoleCounts = new HashMap<>();
+        approvedApplicants.stream()
+                .forEach(applicant -> {
+                    recruitedRoleCounts.putIfAbsent(applicant.getRole().getId(), 0L);
+
+                    recruitedRoleCounts.put(applicant.getRole().getId(),
+                            recruitedRoleCounts.get(applicant.getRole().getId()) + 1);
+                });
+
+        return recruitedRoleCounts;
+    }
+
     @Transactional
-    public void approveApplicants(List<Long> applicantIds, List<RecruitmentApplicant> applicants, Long userId) {
+    public void approveApplicants(List<RecruitmentApplicant> applicants, List<Long> applicantIds, Long userId) {
         validateCanApprove(applicants, userId);
         validateApplicantCount(applicantIds.size(), applicants.size());
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
@@ -1,9 +1,13 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant.service;
 
+import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantExceptionType.INVALID_REQUEST;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
 import synk.meeteam.domain.recruitment.recruitment_applicant.repository.RecruitmentApplicantRepository;
 
 @Service
@@ -14,5 +18,33 @@ public class RecruitmentApplicantService {
     @Transactional
     public void registerRecruitmentApplicant(RecruitmentApplicant recruitmentApplicant) {
         recruitmentApplicantRepository.save(recruitmentApplicant);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecruitmentApplicant> getAllApplicants(List<Long> applicantIds) {
+        return recruitmentApplicantRepository.findAllById(applicantIds);
+    }
+
+    @Transactional
+    public void approveApplicants(List<Long> applicantIds, List<RecruitmentApplicant> applicants, Long userId) {
+        validateCanApprove(applicants, userId);
+        validateApplicantCount(applicantIds.size(), applicants.size());
+
+        recruitmentApplicantRepository.bulkApprove(applicantIds);
+    }
+
+    private void validateCanApprove(List<RecruitmentApplicant> applicants, Long userId) {
+        // applicants 검증로직
+        // 호출한 사용자가 구인글 작성자인지 확인
+        // status가 다 NONE인지 확인
+
+        applicants.stream()
+                .forEach(applicant -> applicant.validateCanApprove(userId));
+    }
+
+    private void validateApplicantCount(int requestCount, int actualCount) {
+        if (requestCount != actualCount) {
+            throw new RecruitmentApplicantException(INVALID_REQUEST);
+        }
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
@@ -24,7 +24,7 @@ public class RecruitmentApplicantService {
 
     @Transactional(readOnly = true)
     public List<RecruitmentApplicant> getAllApplicants(List<Long> applicantIds) {
-        return recruitmentApplicantRepository.findAllById(applicantIds);
+        return recruitmentApplicantRepository.findAllInApplicantId(applicantIds);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -29,6 +29,7 @@ import synk.meeteam.domain.common.tag.dto.TagDto;
 import synk.meeteam.domain.common.tag.entity.TagType;
 import synk.meeteam.domain.common.university.entity.University;
 import synk.meeteam.domain.recruitment.bookmark.service.BookmarkService;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
 import synk.meeteam.domain.recruitment.recruitment_comment.service.RecruitmentCommentService;
@@ -159,7 +160,8 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         RecruitmentRole recruitmentRole = recruitmentRoleService.findAppliableRecruitmentRole(requestDto.applyRoleId());
 
         RecruitmentApplicant recruitmentApplicant = recruitmentPostMapper.toRecruitmentApplicantEntity(
-                recruitmentRole.getRecruitmentPost(), recruitmentRole.getRole(), user, requestDto.message());
+                recruitmentRole.getRecruitmentPost(), recruitmentRole.getRole(), user, requestDto.message(),
+                RecruitStatus.NONE);
 
         recruitmentPostFacade.applyRecruitment(recruitmentRole, recruitmentApplicant);
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/RecruitmentPostMapper.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/RecruitmentPostMapper.java
@@ -10,6 +10,7 @@ import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.common.skill.entity.Skill;
 import synk.meeteam.domain.common.tag.entity.Tag;
 import synk.meeteam.domain.common.tag.entity.TagType;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.request.CreateCommentRequestDto;
@@ -40,7 +41,7 @@ public interface RecruitmentPostMapper {
 
     @Mapping(source = "user", target = "applicant")
     RecruitmentApplicant toRecruitmentApplicantEntity(RecruitmentPost recruitmentPost, Role role, User user,
-                                                      String comment);
+                                                      String comment, RecruitStatus recruitStatus);
 
     @Mapping(source = "requestDto.content", target = "content")
     RecruitmentComment toRecruitmentCommentEntity(RecruitmentPost recruitmentPost, CreateCommentRequestDto requestDto);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/entity/RecruitmentPost.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/entity/RecruitmentPost.java
@@ -210,4 +210,10 @@ public class RecruitmentPost extends BaseEntity {
         this.bookmarkCount -= 1;
         return this;
     }
+
+    public void incrementResponseCount(Long userId, long responseCount) {
+        validateWriter(userId);
+
+        this.responseCount += responseCount;
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
@@ -93,4 +93,10 @@ public class RecruitmentPostService {
 
         return recruitmentPost;
     }
+
+    @Transactional
+    public void incrementResponseCount(Long postId, Long userId, long responseCount) {
+        RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(postId);
+        recruitmentPost.incrementResponseCount(userId, responseCount);
+    }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/entity/RecruitmentRole.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/entity/RecruitmentRole.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.recruitment.recruitment_role.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantExceptionType.INVALID_USER;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_role_skill.entity.RecruitmentRoleSkill;
 
@@ -61,5 +63,17 @@ public class RecruitmentRole {
 
     public void addApplicantCount() {
         this.applicantCount += 1;
+    }
+
+    public void incrementRecruitedCount(long recruitedCount, Long userId) {
+        validateWriter(userId);
+
+        this.recruitedCount += recruitedCount;
+    }
+
+    private void validateWriter(Long userId) {
+        if (!this.getRecruitmentPost().getCreatedBy().equals(userId)) {
+            throw new RecruitmentApplicantException(INVALID_USER);
+        }
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
@@ -27,4 +27,7 @@ public interface RecruitmentRoleRepository extends JpaRepository<RecruitmentRole
     }
 
     void deleteAllByRecruitmentPostId(Long postId);
+
+    @Query("SELECT r FROM RecruitmentRole r JOIN FETCH r.recruitmentPost p JOIN FETCH r.role t WHERE p.id = :postId AND t.id IN :roleIds")
+    List<RecruitmentRole> findAllByPostIdAndRoleIds(@Param("postId") Long postId, @Param("roleIds") List<Long> roleIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/service/RecruitmentRoleService.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.recruitment.recruitment_role.service;
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,4 +55,16 @@ public class RecruitmentRoleService {
     public List<RecruitmentRole> findApplyStatusRecruitmentRole(Long postId) {
         return recruitmentRoleRepository.findAllByPostIdWithRecruitmentRoleAndRole(postId);
     }
+
+    @Transactional
+    public void incrementRecruitedCount(Long postId, Long userId, List<Long> roleIds, Map<Long, Long> recruitedCounts) {
+        List<RecruitmentRole> recruitmentRoles = recruitmentRoleRepository.findAllByPostIdAndRoleIds(postId, roleIds);
+
+        recruitmentRoles.stream()
+                .forEach(recruitmentRole -> {
+                    long recruitedCount = recruitedCounts.get(recruitmentRole.getRole().getId());
+                    recruitmentRole.incrementRecruitedCount(recruitedCount, userId);
+                });
+    }
+
 }

--- a/src/main/java/synk/meeteam/infra/mail/MailService.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailService.java
@@ -3,9 +3,7 @@ package synk.meeteam.infra.mail;
 import static synk.meeteam.domain.auth.exception.AuthExceptionType.INVALID_MAIL_SERVICE;
 import static synk.meeteam.infra.mail.MailText.CHAR_SET;
 import static synk.meeteam.infra.mail.MailText.FRONT_DOMAIN;
-import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_POSTFIX_APPROVE;
 import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_POSTFIX_SIGNUP;
-import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_PREFIX_APPROVE;
 import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_PREFIX_SIGNUP;
 import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_APPROVE;
 import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_SIGNUP;
@@ -23,8 +21,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 import synk.meeteam.domain.auth.exception.AuthException;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.entity.UserVO;
 import synk.meeteam.infra.redis.repository.RedisUserRepository;
 
@@ -36,13 +37,25 @@ public class MailService {
     private final JavaMailSender mailSender;
     private final RedisUserRepository redisUserRepository;
 
+    private final TemplateEngine templateEngine;
+
     private static String createMailContent(String emailCode) {
         return MAIL_CONTENT_PREFIX_SIGNUP + FRONT_DOMAIN + emailCode + MAIL_CONTENT_POSTFIX_SIGNUP;
     }
 
-    private static String createApproveMailContent(Long postId) {
-        return MAIL_CONTENT_PREFIX_APPROVE + "localhost:8080/recruitment/postings/" + postId.toString()
-                + MAIL_CONTENT_POSTFIX_APPROVE;
+    public String generateHtml(String templatePath, String userName, String postId, String postName, String roleName,
+                               String writerName) {
+
+        // Thymeleaf context 생성
+        Context context = new Context();
+        context.setVariable("userName", userName);
+        context.setVariable("postName", postName);
+        context.setVariable("postId", postId);
+        context.setVariable("roleName", roleName);
+        context.setVariable("writerName", writerName);
+
+        // Thymeleaf 템플릿 엔진을 사용하여 변수 값을 주입하여 HTML 렌더링
+        return templateEngine.process(templatePath, context);
     }
 
     @Transactional
@@ -72,22 +85,25 @@ public class MailService {
     }
 
     @Transactional
-    public void sendApproveMails(Long postId, List<RecruitmentApplicant> applicants) {
+    public void sendApproveMails(Long postId, List<RecruitmentApplicant> applicants, String writerName) {
         if (applicants == null) {
             return;
         }
         MimeMessage message = mailSender.createMimeMessage();
 
         for (RecruitmentApplicant recruitmentApplicant : applicants) {
+            User applicant = recruitmentApplicant.getApplicant();
             String receiverMail =
-                    recruitmentApplicant.getApplicant().isUniversityMainEmail() ? recruitmentApplicant.getApplicant()
-                            .getUniversityEmail() : recruitmentApplicant.getApplicant().getSubEmail();
+                    applicant.isUniversityMainEmail() ? applicant.getUniversityEmail() : applicant.getSubEmail();
 
             try {
                 message.addRecipients(RecipientType.TO, receiverMail);// 보내는 대상
                 message.setSubject(MAIL_TITLE_APPROVE);// 제목
 
-                String body = createApproveMailContent(postId);
+                String body = generateHtml(
+                        "ApproveMail", applicant.getName(), postId.toString(),
+                        recruitmentApplicant.getRecruitmentPost().getTitle(),
+                        recruitmentApplicant.getRole().getName(), writerName);
 
                 message.setText(body, CHAR_SET, SUB_TYPE);// 내용, charset 타입, subtype
                 // 보내는 사람의 이메일 주소, 보내는 사람 이름

--- a/src/main/java/synk/meeteam/infra/mail/MailService.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailService.java
@@ -78,9 +78,10 @@ public class MailService {
         }
         MimeMessage message = mailSender.createMimeMessage();
 
-        for (RecruitmentApplicant applicant : applicants) {
-            String receiverMail = applicant.getApplicant().isUniversityMainEmail() ? applicant.getApplicant()
-                    .getUniversityEmail() : applicant.getApplicant().getSubEmail();
+        for (RecruitmentApplicant recruitmentApplicant : applicants) {
+            String receiverMail =
+                    recruitmentApplicant.getApplicant().isUniversityMainEmail() ? recruitmentApplicant.getApplicant()
+                            .getUniversityEmail() : recruitmentApplicant.getApplicant().getSubEmail();
 
             try {
                 message.addRecipients(RecipientType.TO, receiverMail);// 보내는 대상

--- a/src/main/java/synk/meeteam/infra/mail/MailService.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailService.java
@@ -3,9 +3,12 @@ package synk.meeteam.infra.mail;
 import static synk.meeteam.domain.auth.exception.AuthExceptionType.INVALID_MAIL_SERVICE;
 import static synk.meeteam.infra.mail.MailText.CHAR_SET;
 import static synk.meeteam.infra.mail.MailText.FRONT_DOMAIN;
-import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_POSTFIX;
-import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_PREFIX;
-import static synk.meeteam.infra.mail.MailText.MAIL_TITLE;
+import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_POSTFIX_APPROVE;
+import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_POSTFIX_SIGNUP;
+import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_PREFIX_APPROVE;
+import static synk.meeteam.infra.mail.MailText.MAIL_CONTENT_PREFIX_SIGNUP;
+import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_APPROVE;
+import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_SIGNUP;
 import static synk.meeteam.infra.mail.MailText.SENDER;
 import static synk.meeteam.infra.mail.MailText.SENDER_ADDRESS;
 import static synk.meeteam.infra.mail.MailText.SUB_TYPE;
@@ -13,6 +16,7 @@ import static synk.meeteam.infra.mail.MailText.SUB_TYPE;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMessage.RecipientType;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +24,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.auth.exception.AuthException;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.user.user.entity.UserVO;
 import synk.meeteam.infra.redis.repository.RedisUserRepository;
 
@@ -30,6 +35,15 @@ public class MailService {
 
     private final JavaMailSender mailSender;
     private final RedisUserRepository redisUserRepository;
+
+    private static String createMailContent(String emailCode) {
+        return MAIL_CONTENT_PREFIX_SIGNUP + FRONT_DOMAIN + emailCode + MAIL_CONTENT_POSTFIX_SIGNUP;
+    }
+
+    private static String createApproveMailContent(Long postId) {
+        return MAIL_CONTENT_PREFIX_APPROVE + "localhost:8080/recruitment/postings/" + postId.toString()
+                + MAIL_CONTENT_POSTFIX_APPROVE;
+    }
 
     @Transactional
     public void sendMail(String platformId, String receiverMail) {
@@ -43,7 +57,7 @@ public class MailService {
 
         try {
             message.addRecipients(RecipientType.TO, receiverMail);// 보내는 대상
-            message.setSubject(MAIL_TITLE);// 제목
+            message.setSubject(MAIL_TITLE_SIGNUP);// 제목
 
             String body = createMailContent(newEmailCode);
 
@@ -57,8 +71,33 @@ public class MailService {
         }
     }
 
-    private static String createMailContent(String emailCode){
-        return MAIL_CONTENT_PREFIX + FRONT_DOMAIN + emailCode + MAIL_CONTENT_POSTFIX;
+    @Transactional
+    public void sendApproveMails(Long postId, List<RecruitmentApplicant> applicants) {
+        if (applicants == null) {
+            return;
+        }
+        MimeMessage message = mailSender.createMimeMessage();
+
+        for (RecruitmentApplicant applicant : applicants) {
+            String receiverMail = applicant.getApplicant().isUniversityMainEmail() ? applicant.getApplicant()
+                    .getUniversityEmail() : applicant.getApplicant().getSubEmail();
+
+            try {
+                message.addRecipients(RecipientType.TO, receiverMail);// 보내는 대상
+                message.setSubject(MAIL_TITLE_APPROVE);// 제목
+
+                String body = createApproveMailContent(postId);
+
+                message.setText(body, CHAR_SET, SUB_TYPE);// 내용, charset 타입, subtype
+                // 보내는 사람의 이메일 주소, 보내는 사람 이름
+                message.setFrom(new InternetAddress(SENDER_ADDRESS, SENDER));// 보내는 사람
+                mailSender.send(message); // 메일 전송
+            } catch (Exception e) {
+                log.info("{}", e);
+                throw new AuthException(INVALID_MAIL_SERVICE);
+            }
+        }
+
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/synk/meeteam/infra/mail/MailText.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailText.java
@@ -1,21 +1,31 @@
 package synk.meeteam.infra.mail;
 
 public class MailText {
-    public static final String MAIL_TITLE = "Meeteam 회원가입 이메일 인증";
-    public static final String MAIL_CONTENT_PREFIX = "<div>"
+    public static final String MAIL_TITLE_SIGNUP = "Meeteam 회원가입 이메일 인증";
+    public static final String MAIL_TITLE_APPROVE = "구인 신청 승인";
+
+    public static final String MAIL_CONTENT_PREFIX_SIGNUP = "<div>"
             + "<h1> 안녕하세요. Meeteam 입니다</h1>"
             + "<br>"
             + "<p>아래 링크를 클릭하면 이메일 인증이 완료됩니다.<p>"
             + "<a href='";
+
+    public static final String MAIL_CONTENT_PREFIX_APPROVE = "<div>"
+            + "<h1> 안녕하세요. Meeteam 입니다</h1>"
+            + "<br>"
+            + "<p>구인 신청 결과에 대해서 전해드리겠습니다!<p>"
+            + "<a href='";
     public static final String FRONT_DOMAIN = "http://localhost:5173/signup/nickname?emailcode=";
-    public static final String MAIL_CONTENT_POSTFIX = "'>인증 링크</a>"
+    public static final String MAIL_CONTENT_POSTFIX_SIGNUP = "'>인증 링크</a>"
+            + "</div>";
+
+    public static final String MAIL_CONTENT_POSTFIX_APPROVE = "'>구인글 링크</a>"
             + "</div>";
 
     public static final String SENDER_ADDRESS = "thdalsrb79@naver.com";
     public static final String SENDER = "Meeteam";
     public static final String CHAR_SET = "utf-8";
     public static final String SUB_TYPE = "html";
-
 
 
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantEntityTest.java
@@ -1,0 +1,62 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant;
+
+import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantExceptionType.ALREADY_PROCESSED_APPLICANT;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import synk.meeteam.domain.common.role.RoleFixture;
+import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
+import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
+import synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
+import synk.meeteam.domain.user.user.UserFixture;
+import synk.meeteam.domain.user.user.entity.User;
+
+public class RecruitmentApplicantEntityTest {
+
+    @Test
+    void 승인가능여부검증_성공() {
+        // given
+        User user = UserFixture.createUserFixture();
+        Role role = RoleFixture.createRole("백엔드개발자");
+        Long userId = 1L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상제목입니다");
+        recruitmentPost.setCreatedBy(userId);
+
+        RecruitmentApplicant recruitmentApplicant = RecruitmentApplicant.builder()
+                .recruitmentPost(recruitmentPost)
+                .applicant(user)
+                .role(role)
+                .comment("나를 뽑아줘")
+                .recruitStatus(RecruitStatus.NONE)
+                .build();
+
+        // when, then
+        recruitmentApplicant.validateCanApprove(userId);
+    }
+
+    @Test
+    void 승인가능여부검증_예외발생_NONE이아닌경우() {
+        // given
+        User user = UserFixture.createUserFixture();
+        Role role = RoleFixture.createRole("백엔드개발자");
+        Long userId = 1L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상제목입니다");
+        recruitmentPost.setCreatedBy(userId);
+
+        RecruitmentApplicant recruitmentApplicant = RecruitmentApplicant.builder()
+                .recruitmentPost(recruitmentPost)
+                .applicant(user)
+                .role(role)
+                .comment("나를 뽑아줘")
+                .recruitStatus(RecruitStatus.APPROVED)
+                .build();
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentApplicant.validateCanApprove(userId))
+                .isInstanceOf(RecruitmentApplicantException.class)
+                .hasMessageContaining(ALREADY_PROCESSED_APPLICANT.message());
+    }
+}

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantFixture.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantFixture.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant;
 
 import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.user.user.entity.User;
@@ -14,6 +15,7 @@ public class RecruitmentApplicantFixture {
                 .applicant(applicant)
                 .role(role)
                 .comment("저 하고 싶어영")
+                .recruitStatus(RecruitStatus.NONE)
                 .build();
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantFixture.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantFixture.java
@@ -18,4 +18,16 @@ public class RecruitmentApplicantFixture {
                 .recruitStatus(RecruitStatus.NONE)
                 .build();
     }
+
+    public static RecruitmentApplicant createApprovedRecruitmentApplicant(RecruitmentPost recruitmentPost,
+                                                                          User applicant,
+                                                                          Role role) {
+        return RecruitmentApplicant.builder()
+                .recruitmentPost(recruitmentPost)
+                .applicant(applicant)
+                .role(role)
+                .comment("저 하고 싶어영")
+                .recruitStatus(RecruitStatus.APPROVED)
+                .build();
+    }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -1,11 +1,14 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant;
 
+import java.util.List;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.common.role.repository.RoleRepository;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
@@ -17,6 +20,7 @@ import synk.meeteam.domain.user.user.repository.UserRepository;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Sql({"classpath:test-recruitment-applicant.sql"})
 public class RecruitmentApplicantRepositoryTest {
 
     @Autowired
@@ -30,6 +34,16 @@ public class RecruitmentApplicantRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+
+    @BeforeEach
+    void init() {
+//        databaseCleanUp.clear();
+//        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+//        populator.addScript(new ClassPathResource("data.sql"));
+//        populator.addScript(new ClassPathResource("test-recruitment-applicant.sql"));
+//        populator.execute(dataSource);
+    }
 
     @Test
     void 신청자저장_신청자정보반환_정상경우() {
@@ -89,5 +103,16 @@ public class RecruitmentApplicantRepositoryTest {
         Assertions.assertThatThrownBy(() -> {
             recruitmentApplicantRepository.saveAndFlush(recruitmentApplicant);
         }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 신청자목록조회_성공() {
+        // given
+
+        // when
+        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllById(List.of(1L, 2L));
+
+        // then
+        Assertions.assertThat(recruitmentApplicants.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -2,7 +2,6 @@ package synk.meeteam.domain.recruitment.recruitment_applicant;
 
 import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -36,22 +35,12 @@ public class RecruitmentApplicantRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-
-    @BeforeEach
-    void init() {
-//        databaseCleanUp.clear();
-//        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-//        populator.addScript(new ClassPathResource("data.sql"));
-//        populator.addScript(new ClassPathResource("test-recruitment-applicant.sql"));
-//        populator.execute(dataSource);
-    }
-
     @Test
     void 신청자저장_신청자정보반환_정상경우() {
         // given
-        Role role = roleRepository.findByIdOrElseThrowException(1L);
-        RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(1L);
-        User user = userRepository.findByIdOrElseThrow(1L);
+        Role role = roleRepository.findByIdOrElseThrowException(2L);
+        RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(2L);
+        User user = userRepository.findByIdOrElseThrow(2L);
 
         RecruitmentApplicant recruitmentApplicant = RecruitmentApplicantFixture.createRecruitmentApplicant(
                 recruitmentPost, user, role);
@@ -71,10 +60,11 @@ public class RecruitmentApplicantRepositoryTest {
     @Test
     void 신청자저장_예외발생_이미신청한경우() {
         // given
+        Long postId = 2L;
         Role role = roleRepository.findByIdOrElseThrowException(1L);
         Role newRole = roleRepository.findByIdOrElseThrowException(2L);
 
-        RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(1L);
+        RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(postId);
         User user = userRepository.findByIdOrElseThrow(1L);
 
         RecruitmentApplicant recruitmentApplicant = RecruitmentApplicantFixture.createRecruitmentApplicant(

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -101,7 +101,8 @@ public class RecruitmentApplicantRepositoryTest {
         // given
 
         // when
-        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllById(List.of(1L, 2L));
+        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllInApplicantId(
+                List.of(1L, 2L));
 
         // then
         Assertions.assertThat(recruitmentApplicants.size()).isEqualTo(2);
@@ -115,7 +116,8 @@ public class RecruitmentApplicantRepositoryTest {
         recruitmentApplicantRepository.bulkApprove(List.of(1L, 2L));
 
         // then
-        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllById(List.of(1L, 2L));
+        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllInApplicantId(
+                List.of(1L, 2L));
         recruitmentApplicants.stream()
                 .forEach(applicant -> {
                     Assertions.assertThat(applicant.getRecruitStatus()).isEqualTo(RecruitStatus.APPROVED);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.common.role.repository.RoleRepository;
+import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.repository.RecruitmentApplicantRepository;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
@@ -114,5 +115,21 @@ public class RecruitmentApplicantRepositoryTest {
 
         // then
         Assertions.assertThat(recruitmentApplicants.size()).isEqualTo(2);
+    }
+
+    @Test
+    void 신청자승인처리_성공() {
+        // given
+
+        // when
+        recruitmentApplicantRepository.bulkApprove(List.of(1L, 2L));
+
+        // then
+        List<RecruitmentApplicant> recruitmentApplicants = recruitmentApplicantRepository.findAllById(List.of(1L, 2L));
+        recruitmentApplicants.stream()
+                .forEach(applicant -> {
+                    Assertions.assertThat(applicant.getRecruitStatus()).isEqualTo(RecruitStatus.APPROVED);
+                });
+
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostEntityTest.java
@@ -126,4 +126,32 @@ public class RecruitmentPostEntityTest {
 
     }
 
+    @Test
+    void 응답횟수증가_성공() {
+        // given
+        Long userId = 1L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        recruitmentPost.setCreatedBy(userId);
+
+        // when
+        recruitmentPost.incrementResponseCount(userId, 3L);
+
+        // then
+        Assertions.assertThat(recruitmentPost.getResponseCount()).isEqualTo(3L);
+    }
+
+    @Test
+    void 응답횟수증가_예외발생_작성자가아닌경우() {
+        // given
+        Long userId = 1L;
+        Long writerId = 2L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상 제목입니다.");
+        recruitmentPost.setCreatedBy(writerId);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentPost.incrementResponseCount(userId, 3L))
+                .isInstanceOf(RecruitmentPostException.class)
+                .hasMessageContaining(INVALID_USER_ID.message());
+    }
+
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleEntityTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleEntityTest.java
@@ -1,0 +1,54 @@
+package synk.meeteam.domain.recruitment.recruitment_role;
+
+import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantExceptionType.INVALID_USER;
+
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import synk.meeteam.domain.common.role.RoleFixture;
+import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
+import synk.meeteam.domain.recruitment.recruitment_post.RecruitmentPostFixture;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
+import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
+
+public class RecruitmentRoleEntityTest {
+
+    @Test
+    void 구인인원증가_성공() {
+        // given
+        Long userId = 1L;
+        long recruitedCount = 2L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상제목입니다");
+        recruitmentPost.setCreatedBy(userId);
+        Role role = RoleFixture.createRole("백엔드개발자");
+        List<RecruitmentRole> recruitmentRoles = RecruitmentRoleFixture.createRecruitmentRoles(recruitmentPost, role);
+
+        // when
+        recruitmentRoles.stream().
+                forEach(recruitmentRole -> recruitmentRole.incrementRecruitedCount(recruitedCount, userId));
+
+        // then
+        recruitmentRoles.stream().
+                forEach(recruitmentRole -> Assertions.assertThat(recruitmentRole.getRecruitedCount())
+                        .isEqualTo(recruitedCount));
+    }
+
+    @Test
+    void 구인인원증가_예외발생_작성자가아닌경우() {
+        // given
+        Long userId = 1L;
+        Long writerId = 2L;
+        long recruitedCount = 2L;
+        RecruitmentPost recruitmentPost = RecruitmentPostFixture.createRecruitmentPost("정상제목입니다");
+        recruitmentPost.setCreatedBy(writerId);
+        Role role = RoleFixture.createRole("백엔드개발자");
+        List<RecruitmentRole> recruitmentRoles = RecruitmentRoleFixture.createRecruitmentRoles(recruitmentPost, role);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentRoles.stream().
+                        forEach(recruitmentRole -> recruitmentRole.incrementRecruitedCount(recruitedCount, userId)))
+                .isInstanceOf(RecruitmentApplicantException.class)
+                .hasMessageContaining(INVALID_USER.message());
+    }
+}

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_role/RecruitmentRoleRepositoryTest.java
@@ -151,4 +151,34 @@ public class RecruitmentRoleRepositoryTest {
         assertThat(availableRoleDtos.size()).isEqualTo(0);
 
     }
+
+    @Test
+    void 구인역할조회_성공_id리스트로조회() {
+        // given
+        Long postId = 1L;
+        List<Long> roleIds = List.of(1L, 2L);
+
+        // when
+        List<RecruitmentRole> recruitmentRoles = recruitmentRoleRepository.findAllByPostIdAndRoleIds(postId,
+                roleIds);
+
+        // then
+        Assertions.assertThat(recruitmentRoles.get(0).getRole().getName()).isEqualTo("소프트웨어 엔지니어");
+        Assertions.assertThat(recruitmentRoles.get(1).getRole().getName()).isEqualTo("웹 개발자");
+
+    }
+
+    @Test
+    void 구인역할조회_성공_id리스트null인경우() {
+        // given
+        Long postId = 1L;
+        List<Long> roleIds = null;
+
+        // when
+        List<RecruitmentRole> recruitmentRoles = recruitmentRoleRepository.findAllByPostIdAndRoleIds(postId,
+                roleIds);
+
+        // then
+        Assertions.assertThat(recruitmentRoles.size()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #182 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 신청자 승인 API 를 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


<img width="573" alt="스크린샷 2024-04-04 오후 11 46 10" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/de80aa7f-3333-445f-b3db-809670bb6682">


### 실행전
<img width="620" alt="스크린샷 2024-04-05 오전 2 28 14" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/5aa6362b-a59b-4810-b076-0217764c4c5e">

<img width="819" alt="스크린샷 2024-04-05 오전 2 28 48" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/31236284-7afb-4b6f-a52c-93f966831777">
<img width="463" alt="스크린샷 2024-04-05 오전 2 29 18" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/2451e177-b03b-444c-b8c7-bf2f46e2a5eb">

### 실행후
<img width="603" alt="스크린샷 2024-04-05 오전 2 29 49" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/4990fec4-529a-4e36-84b4-8cfb1e8d148f">
<img width="1055" alt="스크린샷 2024-04-05 오전 2 29 58" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/50e20c7c-2baa-4ec3-a4c4-d0145307e571">
<img width="444" alt="스크린샷 2024-04-05 오전 2 30 23" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/5fc1de6e-ff9e-48b2-8c11-22893a8dbc5b">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 1차 푸쉬 (테스트 코드 제외하고 완성)
### 벌크 연산 -> 쿼리 횟수 최적화
* 이 부분에 대해서 고민이 많았습니다..!
* 신청자가 1명일 경우에는 로직이 매우 간단하지만, 여러명이 `List` 로 올 수 있는 부분을 생각하다 보니까 복잡해졌는데요!
* 결국 업데이트 쿼리가 굉장히 많이 발생한다는 문제가 있었습니다.
* N명을 승인한다고 가정하고 쿼리 횟수를 비교해보겠습니다.
1. 단순한 방법(더티 체킹 기술을 활용) : `N`(신청자 수 만큼 업데이트 쿼리) + `1`(구인글 응답 횟수 업데이트 쿼리) + `구인역할수만큼`(구인역할 테이블의 구인된 인원을 증가시키기 위해)
2. 벌크 연산 : `1`(신청자 수와 관련없이 1번 업데이트 쿼리) +  `1`(구인글 응답 횟수 업데이트 쿼리) + `구인역할수만큼`(구인역할 테이블의 구인된 인원을 증가시키기 위해)
* 결국 1번과 2번의 차이는 신청자 테이블에서 신청 승인으로 업데이트 쿼리 수를 `N` -> `1` 으로 줄였습니다!
* `구인역할수만큼`의 쿼리 횟수도 `1`번으로 줄이고 싶었는데요!
* 고민하다보니 물리적으로 불가능하지 않나? 라는 생각이 들었습니다.
* 왜냐하면, 구인역할마다 승인된 인원이 다르기 때문에 1번의 쿼리로는 불가능하다고 생각했습니다! (제가 이 부분을 좀 간단하게 설명했는데 혹시 구체적으로 설명필요하시면 말씀주세요!)
* 하지만 부겸님께서 생각하실 때, 좋은 방법이 있어서 `구인역할수만큼`의 쿼리 횟수를 `1`번의 쿼리로 처리할 수 있는 방법이 있다면 정말 환영입니다 ㅎㅎ

### Dirty checking 기술
* 하지만 이렇게 하다보니, 더티체킹으로는 벌크연산이 불가능한가 고민이 들었습니다! 단순 반복적으로 특정 값을 변경하는 행위라면 충분히 벌크 연산으로 처리할 수 있지 않을까 생각했거든요! 
* dirty checking 기술은 개인적으로 객체지향적으로 코드 작성하는데 많은 도움이 되는 기술이라고 생각했는데 벌크 연산이 안된다는 이유로 사용하지 않는 것은 매우 아쉽다고 생각했습니다.
* 제가 해당 기술의 가치를 잘 이해하지 못한 것일 수도 있지만 궁금해서 좀 찾아봤지만 시원한 답변을 찾을 순 없었습니다!
* 그래서 hibernate forum에 글 올려봤습니다! 나중에 답변 달리면 공유드리겠습니다 ㅋㅋ
* https://discourse.hibernate.org/t/doesnt-dirty-checking-technology-have-bulk-operations/9327

## 2차 푸쉬(테스트 코드)
* 로직이 단순한 부분은 테스트 코드 작성에서 제외했습니다.
* test 코드 돌려보고 싶으면, 노션에 `test-recruitment-applicant.sql` 참고해주세요!
* 현재 이쪽에 테스트 코드 문제가 있는데 정확한 원인 파악이 안돼서 일단 뒀습니다..!
<img width="775" alt="스크린샷 2024-04-05 오전 2 25 41" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/9cd068d2-6fc9-4dd2-97cf-aca5e4f0ec7c">
<img width="389" alt="스크린샷 2024-04-05 오전 2 25 58" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/ee2c05c6-47a8-465a-8845-f2635ebdba26">

## 2차 푸쉬(메일 송신 로직 구현)
* 일단 메일 쪽의 메세지는 어떻게 될줄 모르겠어서 임시로 넣었습니다!
* 메일 서비스가 보내는 시간 자체가 절대적으로 최소 2초는 걸리네요.. 이 부분은 나중에 메세지큐 같은거 고민해봐도 좋을 거 같아요!!