### PR TITLE
[DOCS] 신청자 거절 API 스웨거 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantApi.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.ApproveApplicantRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.ProcessApplicantRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.SetLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantInfoResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
@@ -42,5 +43,15 @@ public interface RecruitmentApplicantApi {
     @Operation(summary = "신청자 승인 API")
     ResponseEntity<Void> approveApplicant(@PathVariable("id") Long postId,
                                           @RequestBody ApproveApplicantRequestDto requestDto,
+                                          @AuthUser User user);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "신청자 거절 성공"),
+            }
+    )
+    @Operation(summary = "신청자 거절 API")
+    ResponseEntity<Void> rejectApplicants(@PathVariable("id") Long postId,
+                                          @RequestBody ProcessApplicantRequestDto requestDto,
                                           @AuthUser User user);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.ApproveApplicantRequestDto;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.ProcessApplicantRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.request.SetLinkRequestDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantInfoResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetRecruitmentRoleStatusResponseDto;
@@ -68,6 +69,15 @@ public class RecruitmentApplicantController implements RecruitmentApplicantApi {
     @Override
     public ResponseEntity<Void> approveApplicant(@PathVariable("id") Long postId,
                                                  @RequestBody ApproveApplicantRequestDto requestDto,
+                                                 @AuthUser User user) {
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{id}/reject")
+    @Override
+    public ResponseEntity<Void> rejectApplicants(@PathVariable("id") Long postId,
+                                                 @RequestBody ProcessApplicantRequestDto requestDto,
                                                  @AuthUser User user) {
 
         return ResponseEntity.ok().build();

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/request/ProcessApplicantRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/request/ProcessApplicantRequestDto.java
@@ -1,0 +1,13 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Schema(name = "ApproveApplicantRequestDto", description = "신청자 승인/거절 Dto")
+public record ProcessApplicantRequestDto(
+        @NotNull
+        @Schema(description = "신청 id", example = "\"[1,2,3]\"")
+        List<Long> applicantIds
+) {
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] docs 작업
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #186 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 신청자 거절 API 스웨거

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="1187" alt="스크린샷 2024-04-05 오전 2 37 36" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/ae3920ac-707b-4b70-83b1-8353ce127276">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 누구 담당인지 몰라 두 분다 리뷰어로 뒀습니다~