### PR TITLE
[FIX] 신청자 목록 조회 수정

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,7 +62,9 @@ public interface RecruitmentApplicantApi {
             }
     )
     @Operation(summary = "신청자 목록 조회 API")
-    ResponseEntity<List<GetApplicantResponseDto>> getApplicants(@PathVariable("id") Long postId,
-                                                                @RequestParam(value = "role", required = false) Long roleId,
-                                                                @AuthUser User user);
+    ResponseEntity<GetApplicantResponseDto> getApplicants(@PathVariable("id") Long postId,
+                                                          @RequestParam(value = "role", required = false) Long roleId,
+                                                          @RequestParam(name = "page", defaultValue = "1") int page,
+                                                          @RequestParam(name = "size", defaultValue = "12") int size,
+                                                          @AuthUser User user);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/api/RecruitmentApplicantController.java
@@ -97,10 +97,13 @@ public class RecruitmentApplicantController implements RecruitmentApplicantApi {
 
     @GetMapping("/{id}")
     @Override
-    public ResponseEntity<List<GetApplicantResponseDto>> getApplicants(@PathVariable("id") Long postId,
-                                                                       @RequestParam(value = "role", required = false) Long roleId,
-                                                                       @AuthUser User user) {
-        List<GetApplicantResponseDto> responseDtos = recruitmentApplicantService.getAllByRole(postId, roleId);
+    public ResponseEntity<GetApplicantResponseDto> getApplicants(@PathVariable("id") Long postId,
+                                                                 @RequestParam(value = "role", required = false) Long roleId,
+                                                                 @RequestParam(name = "page", defaultValue = "1") int page,
+                                                                 @RequestParam(name = "size", defaultValue = "8") int size,
+                                                                 @AuthUser User user) {
+
+        GetApplicantResponseDto responseDtos = recruitmentApplicantService.getAllByRole(postId, roleId, page, size);
         return ResponseEntity.ok().body(responseDtos);
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantDto.java
@@ -1,0 +1,59 @@
+package synk.meeteam.domain.recruitment.recruitment_applicant.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(name = "GetApplicantDto", description = "신청자 조회 Dto")
+@Getter
+public class GetApplicantDto {
+
+    @Schema(description = "신청 id", example = "1")
+    Long applicantId;
+    @Schema(description = "유저 id", example = "4OaVE421DSwR63xfKf6vxA==")
+    String userId;
+    @Schema(description = "신청자 닉네임", example = "minji_98")
+    String nickname;
+    @Schema(description = "신청자 프로필 사진", example = "url형태")
+    String profileImg;
+    @Schema(description = "신청자 이름", example = "김민지")
+    String name;
+    @Schema(description = "신청자 평점", example = "4.4")
+    double score;
+    @Schema(description = "대학 이름", example = "광운대학교")
+    String universityName;
+    @Schema(description = "학과 이름", example = "소프트웨어학부")
+    String departmentName;
+    @Schema(description = "이메일", example = "qwer123@naver.com")
+    String email;
+    @Schema(description = "입학년도", example = "2018")
+    int year;
+    @Schema(description = "신청 역할", example = "백엔드개발자")
+    String applyRoleName;
+    @Schema(description = "전하는 말", example = "저 관심있어용")
+    String message;
+
+    @QueryProjection
+    public GetApplicantDto(Long applicantId, String userId, String nickname, String profileImg, String name,
+                           double score, String universityName, String departmentName, String email,
+                           int year,
+                           String applyRoleName, String message) {
+        this.applicantId = applicantId;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+        this.name = name;
+        this.score = score;
+        this.universityName = universityName;
+        this.departmentName = departmentName;
+        this.email = email;
+        this.year = year;
+        this.applyRoleName = applyRoleName;
+        this.message = message;
+    }
+
+    public void setEncryptedUserIdAndProfileImg(String userId, String profileImg) {
+        this.userId = userId;
+        this.profileImg = profileImg;
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantResponseDto.java
@@ -1,59 +1,15 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant.dto.response;
 
-import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
+import java.util.List;
+import synk.meeteam.global.dto.SliceInfo;
 
 
 @Schema(name = "GetApplicantResponseDto", description = "신청자 조회 Dto")
-@Getter
-public class GetApplicantResponseDto {
+public record GetApplicantResponseDto(
         @Schema(description = "신청 id", example = "1")
-        Long applicantId;
-        @Schema(description = "유저 id", example = "4OaVE421DSwR63xfKf6vxA==")
-        String userId;
-        @Schema(description = "신청자 닉네임", example = "minji_98")
-        String nickname;
-        @Schema(description = "신청자 프로필 사진", example = "url형태")
-        String profileImg;
-        @Schema(description = "신청자 이름", example = "김민지")
-        String name;
-        @Schema(description = "신청자 평점", example = "4.4")
-        double score;
-        @Schema(description = "대학 이름", example = "광운대학교")
-        String universityName;
-        @Schema(description = "학과 이름", example = "소프트웨어학부")
-        String departmentName;
-        @Schema(description = "이메일", example = "qwer123@naver.com")
-        String email;
-        @Schema(description = "입학년도", example = "2018")
-        int year;
-        @Schema(description = "신청 역할", example = "백엔드개발자")
-        String applyRoleName;
-        @Schema(description = "전하는 말", example = "저 관심있어용")
-        String message;
+        List<GetApplicantDto> applicants,
+        SliceInfo pageInfo
+) {
 
-        @QueryProjection
-        public GetApplicantResponseDto(Long applicantId, String userId, String nickname, String profileImg, String name,
-                                       double score, String universityName, String departmentName, String email,
-                                       int year,
-                                       String applyRoleName, String message) {
-                this.applicantId = applicantId;
-                this.userId = userId;
-                this.nickname = nickname;
-                this.profileImg = profileImg;
-                this.name = name;
-                this.score = score;
-                this.universityName = universityName;
-                this.departmentName = departmentName;
-                this.email = email;
-                this.year = year;
-                this.applyRoleName = applyRoleName;
-                this.message = message;
-        }
-
-        public void setEncryptedUserIdAndProfileImg(String userId, String profileImg) {
-                this.userId = userId;
-                this.profileImg = profileImg;
-        }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantResponseDto.java
@@ -24,6 +24,8 @@ public class GetApplicantResponseDto {
         String universityName;
         @Schema(description = "학과 이름", example = "소프트웨어학부")
         String departmentName;
+        @Schema(description = "이메일", example = "qwer123@naver.com")
+        String email;
         @Schema(description = "입학년도", example = "2018")
         int year;
         @Schema(description = "신청 역할", example = "백엔드개발자")
@@ -33,7 +35,8 @@ public class GetApplicantResponseDto {
 
         @QueryProjection
         public GetApplicantResponseDto(Long applicantId, String userId, String nickname, String profileImg, String name,
-                                       double score, String universityName, String departmentName, int year,
+                                       double score, String universityName, String departmentName, String email,
+                                       int year,
                                        String applyRoleName, String message) {
                 this.applicantId = applicantId;
                 this.userId = userId;
@@ -43,6 +46,7 @@ public class GetApplicantResponseDto {
                 this.score = score;
                 this.universityName = universityName;
                 this.departmentName = departmentName;
+                this.email = email;
                 this.year = year;
                 this.applyRoleName = applyRoleName;
                 this.message = message;

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepository.java
@@ -1,11 +1,13 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant.repository;
 
 import java.util.List;
-import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantResponseDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 
 public interface RecruitmentApplicantCustomRepository {
     long updateRecruitStatus(List<Long> applicantIds, RecruitStatus recruitStatus);
 
-    List<GetApplicantResponseDto> findByPostIdAndRoleId(Long postId, Long roleId);
+    Slice<GetApplicantDto> findByPostIdAndRoleId(Long postId, Long roleId, Pageable pageable);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
@@ -39,10 +39,10 @@ public class RecruitmentApplicantCustomRepositoryImpl implements RecruitmentAppl
     @Override
     public Slice<GetApplicantDto> findByPostIdAndRoleId(Long postId, Long roleId, Pageable pageable) {
 
-        Predicate predicate = user.isUniversityMainEmail.eq(true);
+        Predicate isUniversityMainEmail = user.isUniversityMainEmail.eq(true);
 
         StringExpression getMainMail = new CaseBuilder()
-                .when(predicate)
+                .when(isUniversityMainEmail)
                 .then(recruitmentApplicant.applicant.universityEmail)
                 .otherwise(recruitmentApplicant.applicant.subEmail);
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
@@ -6,7 +6,10 @@ import static synk.meeteam.domain.recruitment.recruitment_applicant.entity.QRecr
 import static synk.meeteam.domain.recruitment.recruitment_post.entity.QRecruitmentPost.recruitmentPost;
 import static synk.meeteam.domain.user.user.entity.QUser.user;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,14 +36,20 @@ public class RecruitmentApplicantCustomRepositoryImpl implements RecruitmentAppl
     @Override
     public List<GetApplicantResponseDto> findByPostIdAndRoleId(Long postId, Long roleId) {
 
-        // id, profileImg
+        Predicate predicate = user.isUniversityMainEmail.eq(true);
+
+        StringExpression getMainMail = new CaseBuilder()
+                .when(predicate)
+                .then(recruitmentApplicant.applicant.universityEmail)
+                .otherwise(recruitmentApplicant.applicant.subEmail);
+
         return jpaQueryFactory
                 .select(new QGetApplicantResponseDto(recruitmentApplicant.id,
                         recruitmentApplicant.applicant.id.stringValue(),
                         recruitmentApplicant.applicant.nickname, recruitmentApplicant.applicant.profileImgFileName,
                         recruitmentApplicant.applicant.name, recruitmentApplicant.applicant.evaluationScore,
                         recruitmentApplicant.applicant.university.name, recruitmentApplicant.applicant.department.name,
-                        recruitmentApplicant.applicant.admissionYear,
+                        getMainMail, recruitmentApplicant.applicant.admissionYear,
                         recruitmentApplicant.role.name, recruitmentApplicant.comment))
                 .from(recruitmentApplicant)
                 .leftJoin(recruitmentApplicant.applicant, user)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
@@ -62,6 +62,8 @@ public class RecruitmentApplicantCustomRepositoryImpl implements RecruitmentAppl
                 .leftJoin(recruitmentApplicant.applicant.department, QDepartment.department)
                 .where(eqRole(roleId), recruitmentApplicant.recruitmentPost.id.eq(postId),
                         recruitmentApplicant.recruitStatus.eq(RecruitStatus.NONE))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
         return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -77,9 +77,10 @@ public class PortfolioRepositoryTest {
     void 유저포트폴리오조회_조회성공() {
         //given
         User user = userRepository.findById(1L).get();
+        int page = 1;
         //when
         Slice<GetProfilePortfolioDto> userPortfolios = portfolioRepository.findUserPortfoliosByUserOrderByCreatedAtDesc(
-                PageRequest.of(1, 12), user);
+                PageRequest.of(page - 1, 12), user);
         //then
         assertThat(userPortfolios.hasNext()).isEqualTo(false);
         assertThat(userPortfolios.getSize()).isEqualTo(12);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -1,16 +1,19 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant;
 
+import static org.mockito.ArgumentMatchers.any;
+
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.common.role.repository.RoleRepository;
-import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantResponseDto;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.repository.RecruitmentApplicantRepository;
@@ -148,14 +151,14 @@ public class RecruitmentApplicantRepositoryTest {
         Long postId = 1L;
 
         // when
-        List<GetApplicantResponseDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId, null);
+        Slice<GetApplicantDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId, null, any());
 
         // then
-        Assertions.assertThat(responseDtos.size()).isEqualTo(2);
-        Assertions.assertThat(responseDtos.get(0))
+        Assertions.assertThat(responseDtos.getContent().size()).isEqualTo(2);
+        Assertions.assertThat(responseDtos.getContent().get(0))
                 .extracting("nickname", "name", "applyRoleName", "message")
                 .containsExactly("송민규짱짱맨", "송민규", "소프트웨어 엔지니어", "나 잘할 수 있음");
-        Assertions.assertThat(responseDtos.get(1))
+        Assertions.assertThat(responseDtos.getContent().get(1))
                 .extracting("nickname", "name", "applyRoleName", "message")
                 .containsExactly("나부겸짱짱맨", "나부겸", "웹 개발자", "나 잘할 수 있여");
     }
@@ -167,12 +170,12 @@ public class RecruitmentApplicantRepositoryTest {
         Long roleId = 2L;
 
         // when
-        List<GetApplicantResponseDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId,
-                roleId);
+        Slice<GetApplicantDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId,
+                roleId, any());
 
         // then
-        Assertions.assertThat(responseDtos.size()).isEqualTo(1);
-        Assertions.assertThat(responseDtos.get(0))
+        Assertions.assertThat(responseDtos.getContent().size()).isEqualTo(1);
+        Assertions.assertThat(responseDtos.getContent().get(0))
                 .extracting("nickname", "name", "applyRoleName", "message")
                 .containsExactly("나부겸짱짱맨", "나부겸", "웹 개발자", "나 잘할 수 있여");
     }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantRepositoryTest.java
@@ -1,13 +1,13 @@
 package synk.meeteam.domain.recruitment.recruitment_applicant;
 
-import static org.mockito.ArgumentMatchers.any;
-
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -149,9 +149,12 @@ public class RecruitmentApplicantRepositoryTest {
     void 신청자목록조회_NONE신청자목록조회_role설정하지않은경우() {
         // given
         Long postId = 1L;
-
+        int page = 1;
+        Pageable pageable = PageRequest.of(page - 1, 8);
         // when
-        Slice<GetApplicantDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId, null, any());
+
+        Slice<GetApplicantDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId, null,
+                pageable);
 
         // then
         Assertions.assertThat(responseDtos.getContent().size()).isEqualTo(2);
@@ -168,10 +171,12 @@ public class RecruitmentApplicantRepositoryTest {
         // given
         Long postId = 1L;
         Long roleId = 2L;
+        int page = 1;
+        Pageable pageable = PageRequest.of(page - 1, 8);
 
         // when
         Slice<GetApplicantDto> responseDtos = recruitmentApplicantRepository.findByPostIdAndRoleId(postId,
-                roleId, any());
+                roleId, pageable);
 
         // then
         Assertions.assertThat(responseDtos.getContent().size()).isEqualTo(1);

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
@@ -16,6 +16,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.context.ActiveProfiles;
 import synk.meeteam.domain.common.role.RoleFixture;
 import synk.meeteam.domain.common.role.entity.Role;
@@ -387,8 +389,14 @@ public class RecruitmentApplicantServiceTest {
                 "이미지입니다2", "이름입니다2", 4.2, "광운대학교", "소프트웨어학부", "qwer456@naver.com", 2018,
                 "백엔드개발자", "전하는 말입니다2");
 
-        doReturn(List.of(dto1, dto2)).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any(), any());
+        doReturn(new SliceImpl<>(
+                List.of(dto1, dto2),
+                PageRequest.of(1, 12),
+                false
+        )).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any(), any());
+
         doReturn("이미지입니다").when(s3Service).createPreSignedGetUrl(any(), any());
+
         try (MockedStatic<Encryption> utilities = Mockito.mockStatic(Encryption.class)) {
             utilities.when(() -> Encryption.encryptLong(any())).thenReturn("1234");
 

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import synk.meeteam.domain.common.role.RoleFixture;
 import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.dto.response.GetApplicantResponseDto;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
@@ -379,28 +380,28 @@ public class RecruitmentApplicantServiceTest {
         Long postId = 1L;
         Long roleId = null;
 
-        GetApplicantResponseDto dto1 = new GetApplicantResponseDto(1L, "1", "닉네임입니다1",
+        GetApplicantDto dto1 = new GetApplicantDto(1L, "1", "닉네임입니다1",
                 "이미지입니다1", "이름입니다1", 4.3, "광운대학교", "소프트웨어학부", "qwer123@naver.com", 2018,
                 "백엔드개발자", "전하는 말입니다1");
-        GetApplicantResponseDto dto2 = new GetApplicantResponseDto(2L, "2", "닉네임입니다2",
+        GetApplicantDto dto2 = new GetApplicantDto(2L, "2", "닉네임입니다2",
                 "이미지입니다2", "이름입니다2", 4.2, "광운대학교", "소프트웨어학부", "qwer456@naver.com", 2018,
                 "백엔드개발자", "전하는 말입니다2");
 
-        doReturn(List.of(dto1, dto2)).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any());
+        doReturn(List.of(dto1, dto2)).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any(), any());
         doReturn("이미지입니다").when(s3Service).createPreSignedGetUrl(any(), any());
         try (MockedStatic<Encryption> utilities = Mockito.mockStatic(Encryption.class)) {
             utilities.when(() -> Encryption.encryptLong(any())).thenReturn("1234");
 
             // when
-            List<GetApplicantResponseDto> responseDtos = recruitmentApplicantService.getAllByRole(postId, roleId);
+            GetApplicantResponseDto responseDtos = recruitmentApplicantService.getAllByRole(postId, roleId, 1, 12);
 
             // then
-            Assertions.assertThat(responseDtos.size()).isEqualTo(2);
+            Assertions.assertThat(responseDtos.applicants().size()).isEqualTo(2);
 
-            Assertions.assertThat(responseDtos.get(0))
+            Assertions.assertThat(responseDtos.applicants().get(0))
                     .extracting("nickname", "name", "applyRoleName")
                     .containsExactly("닉네임입니다1", "이름입니다1", "백엔드개발자");
-            Assertions.assertThat(responseDtos.get(1))
+            Assertions.assertThat(responseDtos.applicants().get(1))
                     .extracting("nickname", "name", "applyRoleName")
                     .containsExactly("닉네임입니다2", "이름입니다2", "백엔드개발자");
         }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
@@ -380,10 +380,10 @@ public class RecruitmentApplicantServiceTest {
         Long roleId = null;
 
         GetApplicantResponseDto dto1 = new GetApplicantResponseDto(1L, "1", "닉네임입니다1",
-                "이미지입니다1", "이름입니다1", 4.3, "광운대학교", "소프트웨어학부", 2018,
+                "이미지입니다1", "이름입니다1", 4.3, "광운대학교", "소프트웨어학부", "qwer123@naver.com", 2018,
                 "백엔드개발자", "전하는 말입니다1");
         GetApplicantResponseDto dto2 = new GetApplicantResponseDto(2L, "2", "닉네임입니다2",
-                "이미지입니다2", "이름입니다2", 4.2, "광운대학교", "소프트웨어학부", 2018,
+                "이미지입니다2", "이름입니다2", 4.2, "광운대학교", "소프트웨어학부", "qwer456@naver.com", 2018,
                 "백엔드개발자", "전하는 말입니다2");
 
         doReturn(List.of(dto1, dto2)).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any());

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantTest.java
@@ -8,6 +8,7 @@ import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.Re
 import java.net.URI;
 import java.util.List;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +61,15 @@ public class RecruitmentApplicantTest {
         populator.addScript(new ClassPathResource("data.sql"));
         populator.addScript(new ClassPathResource("test-recruitment-applicant.sql"));
         populator.execute(dataSource);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleanUp.clear();
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScript(new ClassPathResource("data.sql"));
+        populator.execute(dataSource);
+
     }
 
 

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostSearchRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostSearchRepositoryTest.java
@@ -21,10 +21,9 @@ import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.global.entity.Category;
 import synk.meeteam.global.entity.Scope;
 
-@Sql({"classpath:test-search-post.sql"})
-@ActiveProfiles("test")
-
 @DataJpaTest
+@ActiveProfiles("test")
+@Sql({"classpath:test-search-post.sql"})
 public class RecruitmentPostSearchRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/
- closed #204

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 신청자 목록 조회에 이메일 추가
- 신청자 목록 무한스크롤로 수정

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="837" alt="스크린샷 2024-04-09 오전 1 02 59" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/ab6d9e7c-ae1a-4c45-a931-a059af85c58b">


<img width="858" alt="스크린샷 2024-04-09 오전 1 02 26" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/bb96843a-1e01-48ff-9327-b972afa2557d">


```
{
    "applicants": [
        {
            "applicantId": 1,
            "userId": "4OaVE421DSwR63xfKf6vxA",
            "nickname": "송민규짱짱맨",
            "profileImg": "https://meeteam-backend-bucket.s3.ap-northeast-2.amazonaws.com/user/40aVE421DSwR63xfKf6vxA%3D%3D.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240408T155832Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAWUWPATOABI5ONYWN%2F20240408%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=21eba567ea1f2cab48e2c229ebc27e850992fc27eaae5b6d0299f3ca2aa506ac",
            "name": "송민규",
            "score": 3.9,
            "universityName": "광운대학교",
            "departmentName": "소프트웨어학부",
            "email": "thdalsrb79@naver.com",
            "year": 2018,
            "applyRoleName": "소프트웨어 엔지니어",
            "message": "나 잘할 수 있음"
        },
        {
            "applicantId": 2,
            "userId": "b_VkcONhMCJIbGlD6yoTkw",
            "nickname": "나부겸짱짱맨",
            "profileImg": "https://meeteam-backend-bucket.s3.ap-northeast-2.amazonaws.com/user/40aVE421DSwR63xfKf6vxA%3D%3D.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240408T155832Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAWUWPATOABI5ONYWN%2F20240408%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=21eba567ea1f2cab48e2c229ebc27e850992fc27eaae5b6d0299f3ca2aa506ac",
            "name": "나부겸",
            "score": 3.9,
            "universityName": "광운대학교",
            "departmentName": "소프트웨어학부",
            "email": "goder79@naver.com",
            "year": 2018,
            "applyRoleName": "웹 개발자",
            "message": "나 잘할 수 있여"
        }
    ],
    "pageInfo": {
        "page": 1,
        "size": 8,
        "hasNextPage": false
    }
}
```


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- main 메일을 어떤 것으로 했는지에 대한 분기처리도 같이 진행했습니다!
- 결과도 `is_university_main_email` 에 따라 다른 결과 반환되는 것 확인했습니다!
- 신청자 목록 조회할 때, 무한스크롤로 수정했습니다!

### RANDOM_PORT 트랜잭션 이슈
- `@SpringBootTest`를 `RANDOM_PORT`로 사용하면 별도의 쓰레드에서 스프링 컨테이너가 실행되는데요! 테스트가 끝나고 이를 롤백시키려면 하나의 트랜잭션으로 묶여야 하는데, 스프링 컨테이너가 실제로 구동되어 테스트와 다른 쓰레드에서 실행되니 하나의 트랜잭션으로 묶일 수 없다고 합니다! 그래서 롤백되지 않는 이슈가 있다고 합니다!
- 그래서 해결방법으로 저희가 예전에 정의했던 `database cleanup` 함수를 사용해서 해결했습니다!
- 하지만 반복되는 부분이 많아 리팩토링 할 여지가 충분한 것 같습니다!
- 이 부분은 추후에 리팩해보도록 하겠습니다..ㅎ
- 참고링크 : https://mangkyu.tistory.com/264