### PR TITLE
[FIX] 프로필 수정 API 닉네임 공개여부 필드 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/user/user/dto/UpdateProfileCommandMapper.java
+++ b/src/main/java/synk/meeteam/domain/user/user/dto/UpdateProfileCommandMapper.java
@@ -16,5 +16,6 @@ public interface UpdateProfileCommandMapper {
     @Mapping(source = "isSubEmailPublic", target = "isPublicSubEmail")
     @Mapping(source = "isUniversityEmailPublic", target = "isPublicUniversityEmail")
     @Mapping(source = "isUniversityMain", target = "isUniversityMainEmail")
+    @Mapping(source = "isUserNamePublic", target = "isPublicName")
     UpdateInfoCommand toUpdateProfileCommand(UpdateProfileRequestDto updateProfileRequestDto);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/synk/meeteam/domain/user/user/dto/request/UpdateProfileRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import synk.meeteam.domain.user.award.dto.UpdateAwardDto;
@@ -17,6 +18,10 @@ public record UpdateProfileRequestDto(
         @NotBlank
         String nickname,
 
+        @Schema(description = "유저이름 공개여부", example = "true")
+        @NotNull
+        boolean isUserNamePublic,
+
         @Schema(description = "프로필사진 url")
         String imageFileName,
 
@@ -25,6 +30,7 @@ public record UpdateProfileRequestDto(
         String phone,
 
         @Schema(description = "전화번호 공개여부")
+        @NotNull
         boolean isPhonePublic,
 
         @Schema(description = "학교 이메일이 주 이메일인지", example = "true")
@@ -36,9 +42,11 @@ public record UpdateProfileRequestDto(
         String subEmail,
 
         @Schema(description = "보조이메일 공개 여부")
+        @NotNull
         boolean isSubEmailPublic,
 
         @Schema(description = "학교이메일 공개여부")
+        @NotNull
         boolean isUniversityEmailPublic,
 
         @Schema(description = "한줄소개", example = "고통을 즐기는 개발자")


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#211
- closed #211

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 프로필 수정 API에 누락된 닉네임 공개여부필드 추가했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
