### PR TITLE
[FIX] 내 포트폴리오 조회 관련 버그 해결

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import static synk.meeteam.domain.portfolio.portfolio.entity.QPortfolio.portfoli
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,9 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
 
     @Override
     public List<Portfolio> findAllByCreatedByAndIsPinTrueOrderByIds(Long userId, List<Long> portfolioIds) {
+        if (portfolioIds.isEmpty()) {
+            return new ArrayList<>();
+        }
 
         return queryFactory
                 .selectFrom(portfolio)
@@ -52,7 +56,7 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
                 .where(portfolio.createdBy.eq(user.getId()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
-                .orderBy(portfolio.createdAt.desc())
+                .orderBy(portfolio.createdAt.desc(), portfolio.id.desc())
                 .fetch();
         return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
     }
@@ -66,10 +70,6 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
     }
 
     NumberExpression<Integer> orderPortfolios(List<Long> ids) {
-        if (ids == null || ids.isEmpty()) {
-            return null;
-        }
-
         // 포트폴리오 ID의 위치를 기준으로 순서를 정의합니다.
         CaseBuilder caseBuilder = new CaseBuilder();
 

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -13,7 +13,7 @@ import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, PortfolioCustomRepository {
     List<Portfolio> findAllByCreatedByAndIsPinTrue(Long userId);
 
-    List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(Long id);
+    List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(Long id);
 
     @Query("SELECT p FROM Portfolio p LEFT JOIN FETCH p.role LEFT JOIN FETCH p.field where p.id=:id")
     Optional<Portfolio> findByIdWithFieldAndRole(@Param("id") Long portfolioId);

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -62,7 +62,7 @@ public class PortfolioServiceImpl implements PortfolioService {
 
     @Override
     public List<Portfolio> getMyPinPortfolio(Long userId) {
-        return portfolioRepository.findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(userId);
+        return portfolioRepository.findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(userId);
     }
 
     @Override
@@ -116,7 +116,7 @@ public class PortfolioServiceImpl implements PortfolioService {
         );
         return portfolio;
     }
-  
+
     @Override
     public Portfolio getPortfolio(Long portfolioId) {
         return portfolioRepository.findByIdWithFieldAndRoleOrElseThrow(portfolioId);

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -55,7 +55,7 @@ public class PortfolioRepositoryTest {
     }
 
     @Test
-    void 특정유저의핀포트폴리오목록조회_특정유저의핀포트폴리오목록반환() {
+    void 나의핀포트폴리오목록조회_나의의핀포트폴리오목록반환() {
         //when
         List<Portfolio> portfolios = portfolioRepository.findAllByCreatedByAndIsPinTrue(1L);
         //then
@@ -63,7 +63,7 @@ public class PortfolioRepositoryTest {
     }
 
     @Test
-    void 나의핀포트폴리오조회_조회성공() {
+    void 나의핀포트폴리오핀순서로조회_조회성공() {
         //when
         List<Portfolio> userPortfolios = portfolioRepository.findAllByCreatedByAndIsPinTrueOrderByIds(1L,
                 List.of(1L, 2L));

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -98,7 +98,7 @@ public class PortfolioServiceTest {
     void 포트폴리오목록조회_목록조회성공() {
         //given
         doReturn(PortfolioFixture.createPortfolioFixtures_1_2()).when(portfolioRepository)
-                .findAllByIsPinTrueAndCreatedByOrderByProceedStartAsc(anyLong());
+                .findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(anyLong());
         //when
         List<Portfolio> userPortfolio = portfolioService.getMyPinPortfolio(anyLong());
         //then


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#224 -> dev
- closed #224

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 내 포트폴리오 조회시에 정렬조건으로 id순을 추가하였습니다.
- 내 핀 포트폴리오 조회시, 정렬기준을 생성일 -> pinOrder 순으로 변경하였습니다.
- 내 핀 포트폴리오 id로 설정하기 위한 조회 시에, 빈 id 리스트에 대한 예외처리 하였습니다.
- 테스트코드 일부 함수명 변경하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
