### PR TITLE
[FEAT] 구인글 관리 API 구현

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/PostManagementApi.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/PostManagementApi.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.web.bind.annotation.RequestParam;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.SimpleRecruitmentPostDto;
 import synk.meeteam.domain.user.user.entity.User;
@@ -21,6 +23,8 @@ public interface PostManagementApi {
     @Operation(summary = "북마크한 구인글 조회")
     @SecurityRequirement(name = "Authorization")
     PageNationDto<SimpleRecruitmentPostDto> getBookmarkPost(@AuthUser User user,
+                                                            @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                            @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                             @RequestParam(value = "is-closed", required = false) Boolean isClosed);
 
     @ApiResponses(
@@ -31,6 +35,8 @@ public interface PostManagementApi {
     @Operation(summary = "내가 신청한 구인글 조회")
     @SecurityRequirement(name = "Authorization")
     PageNationDto<SimpleRecruitmentPostDto> getAppliedPost(@AuthUser User user,
+                                                           @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                           @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                            @RequestParam(value = "is-closed", required = false) Boolean isClosed);
 
     @ApiResponses(
@@ -41,5 +47,7 @@ public interface PostManagementApi {
     @Operation(summary = "내가 작성한 구인글 조회")
     @SecurityRequirement(name = "Authorization")
     PageNationDto<SimpleRecruitmentPostDto> getMyPost(@AuthUser User user,
+                                                      @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                      @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                       @RequestParam(value = "is-closed", required = false) Boolean isClosed);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/PostManagementController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/PostManagementController.java
@@ -1,14 +1,15 @@
 package synk.meeteam.domain.recruitment.recruitment_post.api;
 
-import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import synk.meeteam.domain.recruitment.recruitment_post.dto.response.SimpleRecruitmentPostDto;
+import synk.meeteam.domain.recruitment.recruitment_post.service.RecruitmentPostService;
 import synk.meeteam.domain.user.user.entity.User;
-import synk.meeteam.global.dto.PageInfo;
 import synk.meeteam.global.dto.PageNationDto;
 import synk.meeteam.security.AuthUser;
 
@@ -17,60 +18,32 @@ import synk.meeteam.security.AuthUser;
 @RequestMapping("/management")
 public class PostManagementController implements PostManagementApi {
 
+    private final RecruitmentPostService recruitmentPostService;
+
     @GetMapping("/bookmark")
     @Override
     public PageNationDto<SimpleRecruitmentPostDto> getBookmarkPost(@AuthUser User user,
+                                                                   @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                                   @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                                    @RequestParam(value = "is-closed", required = false) Boolean isClosed) {
-        return new PageNationDto<SimpleRecruitmentPostDto>(
-                List.of(new SimpleRecruitmentPostDto(
-                        1L,
-                        "같이할사람 구합니다.",
-                        "프로젝트",
-                        "goder",
-                        "https://img.png",
-                        "2021-12-15",
-                        "교외",
-                        true
-                )),
-                new PageInfo(1, 24, 1L, 1)
-        );
+        return recruitmentPostService.getBookmarkPost(size, page, user, isClosed);
     }
 
     @GetMapping("/applied")
     @Override
     public PageNationDto<SimpleRecruitmentPostDto> getAppliedPost(@AuthUser User user,
+                                                                  @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                                  @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                                   @RequestParam(value = "is-closed", required = false) Boolean isClosed) {
-        return new PageNationDto<SimpleRecruitmentPostDto>(
-                List.of(new SimpleRecruitmentPostDto(
-                        1L,
-                        "같이할사람 구합니다.",
-                        "프로젝트",
-                        "goder",
-                        "https://img.png",
-                        "2021-12-15",
-                        "교외",
-                        true
-                )),
-                new PageInfo(1, 24, 1L, 1)
-        );
+        return recruitmentPostService.getAppliedPost(size, page, user, isClosed);
     }
 
     @GetMapping("/myPost")
     @Override
     public PageNationDto<SimpleRecruitmentPostDto> getMyPost(@AuthUser User user,
+                                                             @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
+                                                             @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
                                                              @RequestParam(value = "is-closed", required = false) Boolean isClosed) {
-        return new PageNationDto<SimpleRecruitmentPostDto>(
-                List.of(new SimpleRecruitmentPostDto(
-                        1L,
-                        "같이할사람 구합니다.",
-                        "프로젝트",
-                        "goder",
-                        "https://img.png",
-                        "2021-12-15",
-                        "교외",
-                        true
-                )),
-                new PageInfo(1, 24, 1L, 1)
-        );
+        return recruitmentPostService.getMyPost(size, page, user, isClosed);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/SimpleRecruitmentPostMapper.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/SimpleRecruitmentPostMapper.java
@@ -9,5 +9,8 @@ import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.Recruitmen
 public interface SimpleRecruitmentPostMapper {
     @Mapping(target = "category", expression = "java(recruitmentPostVo.getCategory().getName())")
     @Mapping(target = "scope", expression = "java(recruitmentPostVo.getScope().getName())")
-    SimpleRecruitmentPostDto toSimpleRecruitmentPostDto(RecruitmentPostVo recruitmentPostVo);
+    @Mapping(target = "writerProfileImg", source = "writerProfileImg")
+    @Mapping(target = "writerId", source = "writerId")
+    SimpleRecruitmentPostDto toSimpleRecruitmentPostDto(RecruitmentPostVo recruitmentPostVo, String writerId,
+                                                        String writerProfileImg);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/SimpleRecruitmentPostDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/dto/response/SimpleRecruitmentPostDto.java
@@ -9,6 +9,8 @@ public record SimpleRecruitmentPostDto(
         String title,
         @Schema(description = "유형", example = "프로젝트")
         String category,
+        @Schema(description = "작성자 id", example = "sdfkljwncxmv")
+        String writerId,
         @Schema(description = "작성자 닉네임", example = "song123")
         String writerNickname,
         @Schema(description = "작성자 사진", example = "url 형태")
@@ -18,6 +20,8 @@ public record SimpleRecruitmentPostDto(
         @Schema(description = "범위", example = "교내")
         String scope,
         @Schema(description = "북마크 여부", example = "true")
-        Boolean isBookmarked
+        Boolean isBookmarked,
+        @Schema(description = "마감 여부", example = "true")
+        Boolean isClosed
 ) {
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepository.java
@@ -1,0 +1,15 @@
+package synk.meeteam.domain.recruitment.recruitment_post.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.RecruitmentPostVo;
+import synk.meeteam.domain.user.user.entity.User;
+
+public interface RecruitmentManagementRepository {
+    Page<RecruitmentPostVo> findMyBookmarkPost(Pageable pageable, User user, Boolean isClosed);
+
+    Page<RecruitmentPostVo> findMyAppliedPost(Pageable pageable, User user, Boolean isClosed);
+
+    Page<RecruitmentPostVo> findMyPost(Pageable pageable, User user, Boolean isClosed);
+
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
@@ -1,0 +1,184 @@
+package synk.meeteam.domain.recruitment.recruitment_post.repository;
+
+import static synk.meeteam.domain.recruitment.bookmark.entity.QBookmark.bookmark;
+import static synk.meeteam.domain.recruitment.recruitment_applicant.entity.QRecruitmentApplicant.recruitmentApplicant;
+import static synk.meeteam.domain.recruitment.recruitment_post.entity.QRecruitmentPost.recruitmentPost;
+import static synk.meeteam.domain.recruitment.recruitment_post.repository.expression.ExpressionUtils.isClosedEq;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.QRecruitmentPostVo;
+import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.RecruitmentPostVo;
+import synk.meeteam.domain.user.user.entity.QUser;
+import synk.meeteam.domain.user.user.entity.User;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitmentManagementRepositoryImpl implements RecruitmentManagementRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<RecruitmentPostVo> findMyBookmarkPost(Pageable pageable, User user, Boolean isClosed) {
+        List<RecruitmentPostVo> contents = getBookmarkPostVos(pageable, user, isClosed);
+        JPAQuery<Long> countQuery = getBookmarkCount(user, isClosed);
+        return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<RecruitmentPostVo> findMyAppliedPost(Pageable pageable, User user, Boolean isClosed) {
+        List<RecruitmentPostVo> contents = getAppliedPostVos(pageable, user, isClosed);
+        JPAQuery<Long> countQuery = getAppliedCount(user, isClosed);
+        return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<RecruitmentPostVo> findMyPost(Pageable pageable, User user, Boolean isClosed) {
+        List<RecruitmentPostVo> contents = getMyPostVos(pageable, user, isClosed);
+        JPAQuery<Long> countQuery = getMyPostCount(user, isClosed);
+        return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
+    }
+
+    private List<RecruitmentPostVo> getBookmarkPostVos(Pageable pageable, User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        JPAQuery<RecruitmentPostVo> query = queryFactory.select(
+                        new QRecruitmentPostVo(
+                                recruitmentPost.id,
+                                recruitmentPost.title,
+                                recruitmentPost.category,
+                                recruitmentPost.scope,
+                                writer.id,
+                                writer.nickname,
+                                writer.profileImgFileName,
+                                recruitmentPost.deadline,
+                                Expressions.asBoolean(true),
+                                recruitmentPost.createdAt,
+                                recruitmentPost.isClosed
+                        )
+                )
+                .distinct()
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .leftJoin(bookmark).on(recruitmentPost.id.eq(bookmark.recruitmentPost.id))
+                .where(
+                        isClosedEq(isClosed),
+                        bookmark.user.id.eq(userDomain.getId())
+                );
+
+        return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
+                .offset(pageable.getOffset()) //페이지 번호
+                .limit(pageable.getPageSize()) //페이지 사이즈
+                .fetch();
+    }
+
+    private List<RecruitmentPostVo> getAppliedPostVos(Pageable pageable, User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        JPAQuery<RecruitmentPostVo> query = queryFactory.select(
+                        new QRecruitmentPostVo(
+                                recruitmentPost.id,
+                                recruitmentPost.title,
+                                recruitmentPost.category,
+                                recruitmentPost.scope,
+                                writer.id,
+                                writer.nickname,
+                                writer.profileImgFileName,
+                                recruitmentPost.deadline,
+                                Expressions.asBoolean(true),
+                                recruitmentPost.createdAt,
+                                recruitmentPost.isClosed
+                        )
+                )
+                .distinct()
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .leftJoin(recruitmentApplicant).on(recruitmentPost.id.eq(recruitmentApplicant.recruitmentPost.id))
+                .where(
+                        isClosedEq(isClosed),
+                        recruitmentApplicant.applicant.id.eq(userDomain.getId())
+                );
+
+        return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
+                .offset(pageable.getOffset()) //페이지 번호
+                .limit(pageable.getPageSize()) //페이지 사이즈
+                .fetch();
+    }
+
+    private List<RecruitmentPostVo> getMyPostVos(Pageable pageable, User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        JPAQuery<RecruitmentPostVo> query = queryFactory.select(
+                        new QRecruitmentPostVo(
+                                recruitmentPost.id,
+                                recruitmentPost.title,
+                                recruitmentPost.category,
+                                recruitmentPost.scope,
+                                writer.id,
+                                writer.nickname,
+                                writer.profileImgFileName,
+                                recruitmentPost.deadline,
+                                Expressions.asBoolean(true),
+                                recruitmentPost.createdAt,
+                                recruitmentPost.isClosed
+                        )
+                )
+                .distinct()
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .where(
+                        isClosedEq(isClosed),
+                        writer.id.eq(userDomain.getId())
+                );
+
+        return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
+                .offset(pageable.getOffset()) //페이지 번호
+                .limit(pageable.getPageSize()) //페이지 사이즈
+                .fetch();
+    }
+
+    private JPAQuery<Long> getBookmarkCount(User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        return queryFactory.select(recruitmentPost.countDistinct())
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .leftJoin(bookmark).on(recruitmentPost.id.eq(bookmark.recruitmentPost.id))
+                .where(
+                        isClosedEq(isClosed),
+                        bookmark.user.id.eq(userDomain.getId())
+                );
+    }
+
+    private JPAQuery<Long> getAppliedCount(User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        return queryFactory.select(recruitmentPost.countDistinct())
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .leftJoin(recruitmentApplicant).on(recruitmentPost.id.eq(recruitmentApplicant.recruitmentPost.id))
+                .where(
+                        isClosedEq(isClosed),
+                        recruitmentApplicant.applicant.id.eq(userDomain.getId())
+                );
+    }
+
+    private JPAQuery<Long> getMyPostCount(User userDomain, Boolean isClosed) {
+        QUser writer = new QUser("writer");
+
+        return queryFactory.select(recruitmentPost.countDistinct())
+                .from(recruitmentPost)
+                .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
+                .where(
+                        isClosedEq(isClosed),
+                        writer.id.eq(userDomain.getId())
+                );
+    }
+
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
@@ -7,7 +7,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.exception.RecruitmentPostException;
 
 public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost, Long>,
-        RecruitmentPostSearchRepository {
+        RecruitmentPostSearchRepository, RecruitmentManagementRepository {
 
     default RecruitmentPost findByIdOrElseThrow(Long postId) {
         return findById(postId).orElseThrow(() -> new RecruitmentPostException(NOT_FOUND_POST));

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/expression/ExpressionUtils.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/expression/ExpressionUtils.java
@@ -1,0 +1,57 @@
+package synk.meeteam.domain.recruitment.recruitment_post.repository.expression;
+
+import static com.querydsl.jpa.JPAExpressions.selectOne;
+import static synk.meeteam.domain.recruitment.bookmark.entity.QBookmark.bookmark;
+import static synk.meeteam.domain.recruitment.recruitment_post.entity.QRecruitmentPost.recruitmentPost;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import synk.meeteam.domain.user.user.entity.QUser;
+import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.global.entity.Category;
+import synk.meeteam.global.entity.Scope;
+
+public class ExpressionUtils {
+    //BooleanExpression
+    public static BooleanExpression isBookmark(User userDomain) {
+        //로그인 안된 경우
+        if (userDomain == null) {
+            return isFalse();
+        }
+
+        return selectOne()
+                .from(bookmark)
+                .where(
+                        bookmark.user.id.eq(userDomain.getId()),
+                        bookmark.recruitmentPost.id.eq(recruitmentPost.id))
+                .exists();
+    }
+
+    public static BooleanExpression isClosedEq(Boolean isClosed) {
+        return isClosed == null ? null : recruitmentPost.isClosed.eq(isClosed);
+    }
+
+    public static BooleanExpression writerUniversityEq(QUser writer, User userDomain, Scope scope) {
+        return scope != Scope.ON_CAMPUS ? null : writer.university.eq(userDomain.getUniversity());
+    }
+
+    public static BooleanExpression categoryEq(Category category) {
+        return category == null ? null : recruitmentPost.category.eq(category);
+    }
+
+    public static BooleanExpression scopeEq(Scope scope) {
+        if (scope == null) {
+            return null;
+        } else {
+            return recruitmentPost.scope.eq(scope);
+        }
+    }
+
+    public static BooleanExpression titleStartWith(String keyword) {
+        return (keyword == null || keyword.isEmpty()) ? null : recruitmentPost.title.startsWith(keyword);
+    }
+
+    private static BooleanExpression isFalse() {
+        return Expressions.asBoolean(false);
+    }
+}

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/vo/RecruitmentPostVo.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/vo/RecruitmentPostVo.java
@@ -14,24 +14,30 @@ public class RecruitmentPostVo {
     private String title;
     private Category category;
     private Scope scope;
+    private Long writerId;
     private String writerNickname;
     private String writerProfileImg;
     private LocalDate deadline;
     private Boolean isBookmarked;
     private LocalDateTime createdAt;
+    private Boolean isClosed;
 
     @Builder
     @QueryProjection
-    public RecruitmentPostVo(Long id, String title, Category category, String writerNickname, String writerProfileImg,
-                             LocalDate deadline, Scope scope, Boolean isBookmarked, LocalDateTime createdAt) {
+    public RecruitmentPostVo(Long id, String title, Category category, Scope scope, Long writerId,
+                             String writerNickname,
+                             String writerProfileImg, LocalDate deadline, Boolean isBookmarked, LocalDateTime createdAt,
+                             Boolean isClosed) {
         this.id = id;
         this.title = title;
         this.category = category;
+        this.scope = scope;
+        this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImg = writerProfileImg;
         this.deadline = deadline;
-        this.scope = scope;
         this.isBookmarked = isBookmarked;
         this.createdAt = createdAt;
+        this.isClosed = isClosed;
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
@@ -15,6 +15,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.repository.RecruitmentPo
 import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.RecruitmentPostVo;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.global.dto.PageInfo;
+import synk.meeteam.global.dto.PageNationDto;
 import synk.meeteam.global.entity.Scope;
 
 @Service
@@ -111,5 +112,35 @@ public class RecruitmentPostService {
     public void incrementResponseCount(Long postId, Long userId, long responseCount) {
         RecruitmentPost recruitmentPost = recruitmentPostRepository.findByIdOrElseThrow(postId);
         recruitmentPost.incrementResponseCount(userId, responseCount);
+    }
+
+    @Transactional
+    public PageNationDto<SimpleRecruitmentPostDto> getBookmarkPost(int size, int page, User user, Boolean isClosed) {
+        Page<RecruitmentPostVo> postVos = recruitmentPostRepository.findMyBookmarkPost(PageRequest.of(page - 1, size),
+                user, isClosed);
+        PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
+        List<SimpleRecruitmentPostDto> contents = postVos.stream()
+                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+        return new PageNationDto<>(contents, pageInfo);
+    }
+
+    @Transactional
+    public PageNationDto<SimpleRecruitmentPostDto> getAppliedPost(int size, int page, User user, Boolean isClosed) {
+        Page<RecruitmentPostVo> postVos = recruitmentPostRepository.findMyAppliedPost(PageRequest.of(page - 1, size),
+                user, isClosed);
+        PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
+        List<SimpleRecruitmentPostDto> contents = postVos.stream()
+                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+        return new PageNationDto<>(contents, pageInfo);
+    }
+
+    @Transactional
+    public PageNationDto<SimpleRecruitmentPostDto> getMyPost(int size, int page, User user, Boolean isClosed) {
+        Page<RecruitmentPostVo> postVos = recruitmentPostRepository.findMyPost(PageRequest.of(page - 1, size),
+                user, isClosed);
+        PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
+        List<SimpleRecruitmentPostDto> contents = postVos.stream()
+                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+        return new PageNationDto<>(contents, pageInfo);
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
@@ -17,6 +17,9 @@ import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.global.dto.PageInfo;
 import synk.meeteam.global.dto.PageNationDto;
 import synk.meeteam.global.entity.Scope;
+import synk.meeteam.global.util.Encryption;
+import synk.meeteam.infra.s3.S3FileName;
+import synk.meeteam.infra.s3.service.S3Service;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class RecruitmentPostService {
 
     private final RecruitmentPostRepository recruitmentPostRepository;
     private final SimpleRecruitmentPostMapper simpleRecruitmentPostMapper;
+    private final S3Service s3Service;
 
     @Transactional
     public RecruitmentPost writeRecruitmentPost(RecruitmentPost recruitmentPost) {
@@ -93,7 +97,11 @@ public class RecruitmentPostService {
                 .findBySearchConditionAndKeyword(PageRequest.of(page - 1, size), condition, keyword, user);
         PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
-                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+                .map((postVo) -> {
+                    String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
+                    String imageUrl = s3Service.createPreSignedGetUrl(S3FileName.USER, postVo.getWriterProfileImg());
+                    return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
+                }).toList();
 
         return new PaginationSearchPostResponseDto(contents, pageInfo);
     }
@@ -120,7 +128,11 @@ public class RecruitmentPostService {
                 user, isClosed);
         PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
-                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+                .map((postVo) -> {
+                    String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
+                    String imageUrl = s3Service.createPreSignedGetUrl(S3FileName.USER, postVo.getWriterProfileImg());
+                    return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
+                }).toList();
         return new PageNationDto<>(contents, pageInfo);
     }
 
@@ -130,7 +142,11 @@ public class RecruitmentPostService {
                 user, isClosed);
         PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
-                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+                .map((postVo) -> {
+                    String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
+                    String imageUrl = s3Service.createPreSignedGetUrl(S3FileName.USER, postVo.getWriterProfileImg());
+                    return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
+                }).toList();
         return new PageNationDto<>(contents, pageInfo);
     }
 
@@ -140,7 +156,11 @@ public class RecruitmentPostService {
                 user, isClosed);
         PageInfo pageInfo = new PageInfo(page, size, postVos.getTotalElements(), postVos.getTotalPages());
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
-                .map(simpleRecruitmentPostMapper::toSimpleRecruitmentPostDto).toList();
+                .map((postVo) -> {
+                    String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
+                    String imageUrl = s3Service.createPreSignedGetUrl(S3FileName.USER, postVo.getWriterProfileImg());
+                    return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
+                }).toList();
         return new PageNationDto<>(contents, pageInfo);
     }
 }

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostFixture.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_post/RecruitmentPostFixture.java
@@ -52,8 +52,10 @@ public class RecruitmentPostFixture {
 
     public static PaginationSearchPostResponseDto createPageSearchPostResponseDto() {
         List<SimpleRecruitmentPostDto> simpleRecruitmentPostDtos = List.of(
-                new SimpleRecruitmentPostDto(1L, "제목", "프로젝트", "작성자", "이미지", "2022-03-03", "교외", true),
-                new SimpleRecruitmentPostDto(2L, "제목2", "스터디", "작성자", "이미지", "2022-03-03", "교내", false)
+                new SimpleRecruitmentPostDto(1L, "제목", "프로젝트", "dfjksdewnknv", "작성자", "dfjksdewnknv.png", "2022-03-03",
+                        "교외", true, false),
+                new SimpleRecruitmentPostDto(2L, "제목2", "스터디", "sdfjkldfwel", "작성자", "dfjksdewnknv.png", "2022-03-03",
+                        "교내", false, false)
         );
         return new PaginationSearchPostResponseDto(simpleRecruitmentPostDtos, new PageInfo(1, 24, 3L, 1));
     }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#245 -> dev
- closed #245

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 구인글 관리 - 북마크한 구인글
- 구인글 관리 - 신청한 구인글
- 구인글 관리 - 내가 작성한 구인글
- 기존 구인글 검색
  - 필드 추가 : `writerId`, `isClosed` 


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/50174019-63f8-4753-887e-88d274dfc882)
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/a3f8d609-1eb9-4034-9a8f-e87e0876b72a)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 구인글 작성자의 이미지를 도메인의 이미지로 할 것인지 궁금합니다.
  - 만약 그렇다면, 이미지 이름을 클라이언트에서 userId를 받아야 할 것 같습니다.
- 코드가 깔끔하지 못합니다. 혹시 좋은 아이디어 있으면 추천해주시면 감사하겠습니다.