### PR TITLE
[FEAT] 내 포트폴리오 페이지네이션 조회 구현

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioController.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioController.java
@@ -2,7 +2,6 @@ package synk.meeteam.domain.portfolio.portfolio.api;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +17,8 @@ import synk.meeteam.domain.portfolio.portfolio.dto.request.CreatePortfolioReques
 import synk.meeteam.domain.portfolio.portfolio.dto.request.UpdatePortfolioRequestDto;
 import synk.meeteam.domain.portfolio.portfolio.dto.response.GetPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.service.PortfolioFacade;
+import synk.meeteam.domain.portfolio.portfolio.service.PortfolioService;
 import synk.meeteam.domain.user.user.entity.User;
-import synk.meeteam.global.dto.PageInfo;
 import synk.meeteam.global.dto.PaginationPortfolioDto;
 import synk.meeteam.security.AuthUser;
 
@@ -29,6 +28,7 @@ import synk.meeteam.security.AuthUser;
 public class PortfolioController implements PortfolioApi {
 
     private final PortfolioFacade portfolioFacade;
+    private final PortfolioService portfolioService;
 
     @PostMapping
     @Override
@@ -57,19 +57,6 @@ public class PortfolioController implements PortfolioApi {
             @RequestParam(value = "size", required = false, defaultValue = "24") @Valid @Min(1) int size,
             @RequestParam(value = "page", required = false, defaultValue = "1") @Valid @Min(1) int page,
             @AuthUser User user) {
-        return ResponseEntity.ok().body(new PaginationPortfolioDto<>(
-                List.of(
-                        new SimplePortfolioDto(
-                                1L,
-                                "Meeteam",
-                                "https://image.png",
-                                "개발",
-                                "역할",
-                                true,
-                                1
-                        )
-                ),
-                new PageInfo(1, 24, 1L, 1)
-        ));
+        return ResponseEntity.ok().body(portfolioService.getPageMyAllPortfolio(page, size, user));
     }
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepository.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.portfolio.portfolio.repository;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import synk.meeteam.domain.portfolio.portfolio.dto.SimplePortfolioDto;
@@ -8,7 +9,9 @@ import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.user.user.entity.User;
 
 public interface PortfolioCustomRepository {
-    Slice<SimplePortfolioDto> findUserPortfoliosByUserOrderByCreatedAtDesc(Pageable pageable, User user);
+    Slice<SimplePortfolioDto> findSlicePortfoliosByUserOrderByCreatedAtDesc(Pageable pageable, User user);
+
+    Page<SimplePortfolioDto> findPaginationPortfoliosByUserOrderByCreatedAtDesc(Pageable pageable, User user);
 
     List<Portfolio> findAllByCreatedByAndIsPinTrueOrderByIds(Long userId, List<Long> portfolioIds);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
@@ -1,23 +1,27 @@
 package synk.meeteam.domain.portfolio.portfolio.service;
 
 import java.util.List;
+import synk.meeteam.domain.portfolio.portfolio.dto.SimplePortfolioDto;
 import synk.meeteam.domain.portfolio.portfolio.dto.command.CreatePortfolioCommand;
 import synk.meeteam.domain.portfolio.portfolio.dto.command.UpdatePortfolioCommand;
 import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.global.dto.PaginationPortfolioDto;
 
 public interface PortfolioService {
     List<Portfolio> changePinPortfoliosByIds(Long userId, List<Long> portfolioIds);
 
     List<Portfolio> getMyPinPortfolio(Long userId);
 
-    GetUserPortfolioResponseDto getMyAllPortfolio(int page, int size, User user);
+    GetUserPortfolioResponseDto getSliceMyAllPortfolio(int page, int size, User user);
+
+    PaginationPortfolioDto<SimplePortfolioDto> getPageMyAllPortfolio(int page, int size, User user);
 
     Portfolio postPortfolio(CreatePortfolioCommand command);
 
     Portfolio getPortfolio(Long portfolioId);
-  
+
     Portfolio getPortfolio(Long portfolioId, User user);
 
     Portfolio editPortfolio(Portfolio portfolio, User user, UpdatePortfolioCommand command);

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -66,6 +66,6 @@ public class UserController implements UserApi {
     public ResponseEntity<GetUserPortfolioResponseDto> getUserPortfolio(
             @AuthUser User user, @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "12") int size) {
-        return ResponseEntity.ok(portfolioService.getMyAllPortfolio(page, size, user));
+        return ResponseEntity.ok(portfolioService.getSliceMyAllPortfolio(page, size, user));
     }
 }

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -78,7 +78,7 @@ public class PortfolioRepositoryTest {
         User user = userRepository.findById(1L).get();
         int page = 1;
         //when
-        Slice<SimplePortfolioDto> userPortfolios = portfolioRepository.findUserPortfoliosByUserOrderByCreatedAtDesc(
+        Slice<SimplePortfolioDto> userPortfolios = portfolioRepository.findSlicePortfoliosByUserOrderByCreatedAtDesc(
                 PageRequest.of(page - 1, 12), user);
         //then
         assertThat(userPortfolios.hasNext()).isEqualTo(false);

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -109,9 +109,9 @@ public class PortfolioServiceTest {
     void 내포트폴리오목록조회_목록조회성공() {
         //given
         doReturn(PortfolioFixture.createSlicePortfolioDtos()).when(portfolioRepository)
-                .findUserPortfoliosByUserOrderByCreatedAtDesc(eq(PageRequest.of(0, 12)), any());
+                .findSlicePortfoliosByUserOrderByCreatedAtDesc(eq(PageRequest.of(0, 12)), any());
         //when
-        GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getMyAllPortfolio(1, 12,
+        GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getSliceMyAllPortfolio(1, 12,
                 User.builder().build());
 
         //then

--- a/src/test/java/synk/meeteam/domain/user/user/UserControllerTest.java
+++ b/src/test/java/synk/meeteam/domain/user/user/UserControllerTest.java
@@ -126,7 +126,7 @@ public class UserControllerTest {
         //given
         final String url = "/user/portfolios";
         doReturn(PortfolioFixture.createUserAllPortfolios()).when(portfolioService)
-                .getMyAllPortfolio(eq(1), eq(12), any());
+                .getSliceMyAllPortfolio(eq(1), eq(12), any());
         //when
         final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.get(url)


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#256 -> dev
- closed #256

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 포트폴리오 목록 페이지네이션으로 조회하는 API 추가하였습니다.
- 기존의 프로필 페이지에서 제공하던 포트폴리오 목록 조회 API에 이미지 url변환 로직을 추가하였습니다.
- 일부 메소드 명 변경하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/bd434ce4-6aaf-43e8-be77-0b722125e969)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->