### PR TITLE
[CHORE] 구인 글 조회시, 삭제된 구인글 제외조건 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
@@ -18,6 +18,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.QRecruitme
 import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.RecruitmentPostVo;
 import synk.meeteam.domain.user.user.entity.QUser;
 import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.global.entity.DeleteStatus;
 
 @Repository
 @RequiredArgsConstructor
@@ -69,7 +70,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(bookmark).on(recruitmentPost.id.eq(bookmark.recruitmentPost.id))
                 .where(
                         isClosedEq(isClosed),
-                        bookmark.user.id.eq(userDomain.getId())
+                        bookmark.user.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
 
         return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
@@ -102,7 +104,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(recruitmentApplicant).on(recruitmentPost.id.eq(recruitmentApplicant.recruitmentPost.id))
                 .where(
                         isClosedEq(isClosed),
-                        recruitmentApplicant.applicant.id.eq(userDomain.getId())
+                        recruitmentApplicant.applicant.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
 
         return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
@@ -134,7 +137,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
                 .where(
                         isClosedEq(isClosed),
-                        writer.id.eq(userDomain.getId())
+                        writer.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
 
         return query.orderBy(recruitmentPost.createdAt.desc(), recruitmentPost.id.desc())
@@ -152,7 +156,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(bookmark).on(recruitmentPost.id.eq(bookmark.recruitmentPost.id))
                 .where(
                         isClosedEq(isClosed),
-                        bookmark.user.id.eq(userDomain.getId())
+                        bookmark.user.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
     }
 
@@ -165,7 +170,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(recruitmentApplicant).on(recruitmentPost.id.eq(recruitmentApplicant.recruitmentPost.id))
                 .where(
                         isClosedEq(isClosed),
-                        recruitmentApplicant.applicant.id.eq(userDomain.getId())
+                        recruitmentApplicant.applicant.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
     }
 
@@ -177,7 +183,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                 .leftJoin(writer).on(recruitmentPost.createdBy.eq(writer.id))
                 .where(
                         isClosedEq(isClosed),
-                        writer.id.eq(userDomain.getId())
+                        writer.id.eq(userDomain.getId()),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
     }
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
@@ -30,6 +30,7 @@ import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.QRecruitme
 import synk.meeteam.domain.recruitment.recruitment_post.repository.vo.RecruitmentPostVo;
 import synk.meeteam.domain.user.user.entity.QUser;
 import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.global.entity.DeleteStatus;
 import synk.meeteam.global.entity.Scope;
 
 @Repository
@@ -74,7 +75,8 @@ public class RecruitmentPostSearchRepositoryImpl implements RecruitmentPostSearc
                         scopeEq(condition.getScope()),
                         writerUniversityEq(writer, userDomain, condition.getScope()),
                         categoryEq(condition.getCategory()),
-                        titleStartWith(keyword)
+                        titleStartWith(keyword),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
 
         query = jpaUtils.joinWithFieldAndTagAndRoleAndSkill(query, condition);
@@ -100,7 +102,8 @@ public class RecruitmentPostSearchRepositoryImpl implements RecruitmentPostSearc
                         scopeEq(condition.getScope()),
                         writerUniversityEq(writer, userDomain, condition.getScope()),
                         categoryEq(condition.getCategory()),
-                        titleStartWith(keyword)
+                        titleStartWith(keyword),
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
                 );
 
         countQuery = jpaUtils.joinWithFieldAndTagAndRoleAndSkill(countQuery, condition);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#255 -> dev
- closed #255

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 구인글 게시판 및 관리에서 조회시에 삭제된 구인글을 제외하도록 수정하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- not equal(ne)와 equal(eq)중 효율성 측면에서 차이가 있을까요?