### PR TITLE
[FEAT] 포트폴리오 삭제 API 구현

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioApi.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioApi.java
@@ -51,6 +51,14 @@ public interface PortfolioApi {
 
     @ApiResponses(
             value = {
+                    @ApiResponse(responseCode = "200", description = "포트폴리오 삭제 성공"),
+            }
+    )
+    @Operation(summary = "포트폴리오 삭제 API")
+    ResponseEntity<Void> deletePortfolio(@AuthUser User user, @PathVariable Long portfolioId);
+
+    @ApiResponses(
+            value = {
                     @ApiResponse(responseCode = "200", description = "포트폴리오 목록 조회 성공"),
             }
     )

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioController.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/api/PortfolioController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,6 +50,13 @@ public class PortfolioController implements PortfolioApi {
     public ResponseEntity<Long> modifyPortfolio(@AuthUser User user, @PathVariable("id") Long portfolioId,
                                                 @RequestBody @Valid UpdatePortfolioRequestDto requestDto) {
         return ResponseEntity.ok(portfolioFacade.editPortfolio(portfolioId, user, requestDto));
+    }
+
+    @DeleteMapping("/{id}")
+    @Override
+    public ResponseEntity<Void> deletePortfolio(@AuthUser User user, @PathVariable("id") Long portfolioId) {
+        portfolioService.deletePortfolio(portfolioId, user);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
@@ -27,6 +27,7 @@ import org.hibernate.annotations.ColumnDefault;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.global.entity.BaseEntity;
+import synk.meeteam.global.entity.DeleteStatus;
 import synk.meeteam.global.entity.ProceedType;
 import synk.meeteam.global.util.StringListConverter;
 
@@ -100,6 +101,12 @@ public class Portfolio extends BaseEntity {
     @ColumnDefault("0")
     private int pinOrder;
 
+    //삭제 여부
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ALIVE'")
+    private DeleteStatus deleteStatus = DeleteStatus.ALIVE;
+
     @Builder
     public Portfolio(String title, String description, String content, LocalDate proceedStart, LocalDate proceedEnd,
                      ProceedType proceedType, Field field, Role role, String mainImageFileName, String zipFileName,
@@ -158,5 +165,9 @@ public class Portfolio extends BaseEntity {
     public void unpin() {
         isPin = false;
         pinOrder = 0;
+    }
+
+    public void softDelete() {
+        this.deleteStatus = DeleteStatus.DELETED;
     }
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
@@ -36,7 +36,6 @@ import synk.meeteam.global.util.StringListConverter;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.MODULE)
-@Builder
 public class Portfolio extends BaseEntity {
 
     public static int MAX_PIN_SIZE = 8;
@@ -108,9 +107,12 @@ public class Portfolio extends BaseEntity {
     private DeleteStatus deleteStatus = DeleteStatus.ALIVE;
 
     @Builder
-    public Portfolio(String title, String description, String content, LocalDate proceedStart, LocalDate proceedEnd,
+    public Portfolio(Long id, String title, String description, String content, LocalDate proceedStart,
+                     LocalDate proceedEnd,
                      ProceedType proceedType, Field field, Role role, String mainImageFileName, String zipFileName,
+                     Boolean isPin, int pinOrder,
                      List<String> fileOrder) {
+        this.id = id;
         this.title = title;
         this.description = description;
         this.content = content;
@@ -122,15 +124,6 @@ public class Portfolio extends BaseEntity {
         this.mainImageFileName = mainImageFileName;
         this.zipFileName = zipFileName;
         this.fileOrder = fileOrder;
-        this.isPin = false;
-        this.pinOrder = 0;
-    }
-
-    @Builder
-    public Portfolio(Long id, String title, String description, Boolean isPin, int pinOrder) {
-        this.id = id;
-        this.title = title;
-        this.description = description;
         this.isPin = isPin;
         this.pinOrder = pinOrder;
     }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
@@ -36,8 +36,9 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
 
         return queryFactory
                 .selectFrom(portfolio)
-                .where(portfolio.id.in(portfolioIds))
-                .orderBy(orderPortfolios(portfolioIds).asc())
+                .where(portfolio.id.in(portfolioIds),
+                        portfolio.createdBy.eq(userId))
+                .orderBy(orderByPin(portfolioIds).asc())
                 .fetch();
     }
 
@@ -90,8 +91,8 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
                 .where(portfolio.createdBy.eq(user.getId()));
     }
 
-    NumberExpression<Integer> orderPortfolios(List<Long> ids) {
-        // 포트폴리오 ID의 위치를 기준으로 순서를 정의합니다.
+    NumberExpression<Integer> orderByPin(List<Long> ids) {
+        // 포트폴리오 ID의 순서를 기준으로 순서를 정의합니다.
         CaseBuilder caseBuilder = new CaseBuilder();
 
         return caseBuilder

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioService.java
@@ -26,4 +26,6 @@ public interface PortfolioService {
 
     Portfolio editPortfolio(Portfolio portfolio, User user, UpdatePortfolioCommand command);
 
+    void deletePortfolio(Long portfolioId, User user);
+
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.portfolio.portfolio.service;
 
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.NOT_FOUND_PORTFOLIO;
+import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.NOT_YOUR_PORTFOLIO;
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.OVER_MAX_PIN_SIZE;
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.SS_110;
 
@@ -140,6 +141,16 @@ public class PortfolioServiceImpl implements PortfolioService {
                 command.fileOrder()
         );
         return portfolio;
+    }
+
+    @Override
+    public void deletePortfolio(Long portfolioId, User user) {
+        Portfolio portfolio = portfolioRepository.findByIdOrElseThrow(portfolioId);
+        if (portfolio.isWriter(user.getId())) {
+            portfolio.softDelete();
+        } else {
+            throw new PortfolioException(NOT_YOUR_PORTFOLIO);
+        }
     }
 
     @Override

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -126,6 +126,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     }
 
     @Override
+    @Transactional
     public Portfolio editPortfolio(Portfolio portfolio, User user, UpdatePortfolioCommand command) {
         Field field = fieldRepository.findByIdOrElseThrowException(command.fieldId());
         Role role = roleRepository.findByIdOrElseThrowException(command.roleId());
@@ -143,6 +144,7 @@ public class PortfolioServiceImpl implements PortfolioService {
         return portfolio;
     }
 
+    @Transactional
     @Override
     public void deletePortfolio(Long portfolioId, User user) {
         Portfolio portfolio = portfolioRepository.findByIdOrElseThrow(portfolioId);
@@ -153,11 +155,13 @@ public class PortfolioServiceImpl implements PortfolioService {
         }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public Portfolio getPortfolio(Long portfolioId) {
         return portfolioRepository.findByIdWithFieldAndRoleOrElseThrow(portfolioId);
     }
 
+    @Transactional(readOnly = true)
     public Portfolio getPortfolio(Long portfolioId, User user) {
         Portfolio portfolio = portfolioRepository.findByIdOrElseThrow(portfolioId);
 

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
@@ -16,38 +16,16 @@ import synk.meeteam.global.entity.ProceedType;
 public class PortfolioFixture {
     public static List<Portfolio> createPortfolioFixtures_1_2() {
         return List.of(
-                new Portfolio(1L, "타이틀1", "디스크립션1", true, 1),
-                new Portfolio(2L, "타이틀2", "디스크립션2", true, 2)
+                Portfolio.builder().id(1L).title("타이틀1").description("디스크립션1").isPin(true).pinOrder(1).build(),
+                Portfolio.builder().id(2L).title("타이틀2").description("디스크립션2").isPin(true).pinOrder(2).build()
         );
     }
 
     public static List<Portfolio> createPortfolioFixtures_2_1() {
         return List.of(
-                new Portfolio(2L, "타이틀2", "디스크립션2", true, 2),
-                new Portfolio(1L, "타이틀1", "디스크립션1", true, 1)
+                Portfolio.builder().id(2L).title("타이틀2").description("디스크립션2").isPin(true).pinOrder(2).build(),
+                Portfolio.builder().id(1L).title("타이틀1").description("디스크립션1").isPin(true).pinOrder(1).build()
         );
-    }
-
-    public static Portfolio createUserPortfolio(String title, boolean isPin, int pinOrder, Long createdBy,
-                                                LocalDate start, Role role,
-                                                Field field) {
-        Portfolio portfolio = Portfolio.builder()
-                .title(title)
-                .content("컨텐츠")
-                .description("디스크립션")
-                .proceedStart(start)
-                .proceedEnd(LocalDate.now())
-                .proceedType(ProceedType.ON_LINE)
-                .isPin(isPin)
-                .pinOrder(pinOrder)
-                .mainImageFileName("이미지.png")
-                .zipFileName("집.zip")
-                .fileOrder(List.of("집1", "집2"))
-                .role(role)
-                .field(field)
-                .build();
-        portfolio.setCreatedBy(createdBy);
-        return portfolio;
     }
 
     public static Portfolio createPortfolioFixture() {

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.field.repository.FieldRepository;
 import synk.meeteam.domain.common.role.entity.Role;
@@ -24,6 +25,7 @@ import synk.meeteam.global.entity.ProceedType;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Sql({"classpath:test-portfolio.sql"})
 public class PortfolioRepositoryTest {
 
     @Autowired
@@ -44,14 +46,6 @@ public class PortfolioRepositoryTest {
     void setup() {
         role = roleRepository.findById(1L).get();
         field = fieldRepository.findById(1L).get();
-
-        List<Portfolio> portfolios = List.of(
-                PortfolioFixture.createUserPortfolio("타이틀1", true, 1, 1L, LocalDate.of(2024, 1, 2), role, field),
-                PortfolioFixture.createUserPortfolio("타이틀2", true, 2, 1L, LocalDate.of(2024, 1, 3), role, field),
-                PortfolioFixture.createUserPortfolio("타이틀3", false, 3, 1L, LocalDate.of(2024, 1, 4), role, field),
-                PortfolioFixture.createUserPortfolio("타이틀4", true, 1, 2L, LocalDate.of(2024, 1, 4), role, field)
-        );
-        portfolioRepository.saveAllAndFlush(portfolios);
     }
 
     @Test
@@ -69,7 +63,6 @@ public class PortfolioRepositoryTest {
                 List.of(1L, 2L));
         //then
         assertThat(userPortfolios).extracting("title").containsExactly("타이틀1", "타이틀2");
-
     }
 
     @Test
@@ -89,9 +82,10 @@ public class PortfolioRepositoryTest {
     @Test
     void 포트폴리오등록_등록성공() {
         //given
-        Portfolio portfolio = new Portfolio("Meeteam",
-                "대학생 맞춤형 구인 포트폴리오 서비스",
-                "밋팀(Meeteam)은 나 자신을 의미하는 Me, 팀을 의미하는 Team, 만남을 의미하는 Meet이 합쳐진 단어입니다.\n"
+        Portfolio portfolio = Portfolio.builder()
+                .title("Meeteam")
+                .description("대학생 맞춤형 구인 포트폴리오 서비스")
+                .content("밋팀(Meeteam)은 나 자신을 의미하는 Me, 팀을 의미하는 Team, 만남을 의미하는 Meet이 합쳐진 단어입니다.\n"
                         + "대학생들의 보다 원활한 팀프로젝트를 위해 기획하게 되었습니다.\n"
                         + "\n"
                         + "\n"
@@ -100,13 +94,16 @@ public class PortfolioRepositoryTest {
                         + "\n"
                         + "이를 위해 함께 멋진 서비스를 완성할 웹 디자이너를 찾고 있어요!\n"
                         + "밋팀(Meeteam)은 나 자신을 의미하는 Me, 팀을 의미하는 Team, 만남을 의미하는 Meet이 합쳐진 단어입니다.\n"
-                        + "대학생들의 보다 원활한 팀프로젝트를 위해 기획하게 되었으며, 그 외에 포토폴리오로서의 기능까지 생각하고 있습니다!\n",
-                LocalDate.of(2023, 11, 2),
-                LocalDate.of(2024, 3, 15),
-                ProceedType.ON_LINE, field, role,
-                "sdkfjldkfcjemqq.png",
-                "sdkflsdfjfklwemq.zip",
-                List.of("이미지1.png", "이미지2.png"));
+                        + "대학생들의 보다 원활한 팀프로젝트를 위해 기획하게 되었으며, 그 외에 포토폴리오로서의 기능까지 생각하고 있습니다!\n")
+                .proceedStart(LocalDate.of(2023, 11, 2))
+                .proceedEnd(LocalDate.of(2024, 3, 15))
+                .proceedType(ProceedType.ON_LINE)
+                .field(field)
+                .role(role)
+                .mainImageFileName("sdkfjldkfcjemqq.png")
+                .zipFileName("sdkflsdfjfklwemq.zip")
+                .fileOrder(List.of("이미지1.png", "이미지2.png"))
+                .build();
         //when
         Portfolio savedPortfolio = portfolioRepository.saveAndFlush(portfolio);
 


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#253 -> dev
- closed #253

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 포트폴리오 삭제 API 구현하였습니다.
- 핀 포트폴리오 조회 로직에 자신의 포트폴리오만 조회하는 로직이 빠져있어 추가하였습니다.
- 기존 테스트 코드 문제있는 부분을 해결하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/c7ebcd78-8ec0-4276-9614-13e182071085)
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/6c4356e3-241b-4086-8eb4-747d18c979c9)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 알려주신 자료를 참고하여 sequence가 변하지 않도록 `test-portfolio.sql` 을 추가하여 테스트 코드 문제를 해결하였습니다.