### PR TITLE
[FIX] 구인글 마감인 경우 제외하도록 수정

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
@@ -76,7 +76,8 @@ public class RecruitmentPostSearchRepositoryImpl implements RecruitmentPostSearc
                         writerUniversityEq(writer, userDomain, condition.getScope()),
                         categoryEq(condition.getCategory()),
                         titleStartWith(keyword),
-                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED),
+                        recruitmentPost.isClosed.isFalse()
                 );
 
         query = jpaUtils.joinWithFieldAndTagAndRoleAndSkill(query, condition);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#272 -> dev
- closed #272

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 기존 구인글 게시판에서 조회되는 검색 API에 마감된 구인글이 제공되는 부분을 제공하지 않도록 변경하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
