### PR TITLE
[FEAT] 구인 신청시 메일 발송 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,11 +58,15 @@ jobs:
           
           touch ./UniversityAuthMail.html
           echo "$MAIL_VERIFY_TEMPLATE" > ./UniversityAuthMail.html
+          
+          touch ./ApplicationNotificationMail.html
+          echo "MAIL_APPLICATION_NOTIFICATION_TEMPLATE" > ./ApplicationNotificationMail.html
 
         env:
           APPLICATION_DEV: ${{ secrets.APPLICATION_DEV }}
           MAIL_APPROVE_TEMPLATE: ${{ secrets.MAIL_APPROVE_TEMPLATE }}
           MAIL_VERIFY_TEMPLATE: ${{ secrets.MAIL_VERIFY_TEMPLATE }}
+          MAIL_APPLICATION_NOTIFICATION_TEMPLATE: ${{ secrets.MAIL_APPLICATION_NOTIFICATION_TEMPLATE }}
         shell: bash
 
       - name: Gradle 권한 부여

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -177,8 +177,9 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         RecruitmentApplicant recruitmentApplicant = recruitmentPostMapper.toRecruitmentApplicantEntity(
                 recruitmentRole.getRecruitmentPost(), recruitmentRole.getRole(), user, requestDto.message(),
                 RecruitStatus.NONE);
-
-        recruitmentPostFacade.applyRecruitment(recruitmentRole, recruitmentApplicant);
+        RecruitmentPost recruitmentPost = recruitmentPostService.getRecruitmentPost(postId);
+        User writer = userService.findById(recruitmentPost.getCreatedBy());
+        recruitmentPostFacade.applyRecruitment(recruitmentRole, recruitmentApplicant, writer);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/facade/RecruitmentPostFacade.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/facade/RecruitmentPostFacade.java
@@ -20,6 +20,7 @@ import synk.meeteam.domain.recruitment.recruitment_role_skill.service.Recruitmen
 import synk.meeteam.domain.recruitment.recruitment_tag.entity.RecruitmentTag;
 import synk.meeteam.domain.recruitment.recruitment_tag.service.RecruitmentTagService;
 import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.infra.mail.MailService;
 
 
 @Service
@@ -32,6 +33,7 @@ public class RecruitmentPostFacade {
     private final RecruitmentApplicantService recruitmentApplicantService;
     private final BookmarkService bookmarkService;
 
+    private final MailService mailService;
 
     @Transactional
     public Long createRecruitmentPost(RecruitmentPost recruitmentPost, List<RecruitmentRole> recruitmentRoles,
@@ -61,12 +63,16 @@ public class RecruitmentPostFacade {
     }
 
     @Transactional
-    public void applyRecruitment(RecruitmentRole recruitmentRole, RecruitmentApplicant recruitmentApplicant) {
+    public void applyRecruitment(RecruitmentRole recruitmentRole, RecruitmentApplicant recruitmentApplicant,
+                                 User writer) {
         recruitmentApplicantService.registerRecruitmentApplicant(recruitmentApplicant);
 
         recruitmentPostService.incrementApplicantCount(recruitmentApplicant.getRecruitmentPost());
 
         recruitmentRoleService.incrementApplicantCount(recruitmentRole);
+
+        mailService.sendApplicationNotificationMail(recruitmentApplicant.getRecruitmentPost().getId(),
+                recruitmentApplicant, writer);
     }
 
     @Transactional

--- a/src/main/java/synk/meeteam/domain/user/user/entity/User.java
+++ b/src/main/java/synk/meeteam/domain/user/user/entity/User.java
@@ -301,4 +301,8 @@ public class User extends BaseTimeEntity {
     public void processFirstAccess() {
         this.isFirstApplicantAccess = false;
     }
+
+    public String getMainEmail(){
+        return isUniversityMainEmail ? universityEmail : subEmail;
+    }
 }

--- a/src/main/java/synk/meeteam/infra/mail/MailService.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailService.java
@@ -4,7 +4,9 @@ import static synk.meeteam.domain.auth.exception.AuthExceptionType.INVALID_MAIL_
 import static synk.meeteam.infra.mail.MailText.CHAR_SET;
 import static synk.meeteam.infra.mail.MailText.FRONT_VERIFY_DOMAIN;
 import static synk.meeteam.infra.mail.MailText.LOGO_URL;
+import static synk.meeteam.infra.mail.MailText.MAIL_APPLICATION_NOTIFICATION_TEMPLATE;
 import static synk.meeteam.infra.mail.MailText.MAIL_APPROVE_TEMPLATE;
+import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_APPLICATION;
 import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_APPROVE;
 import static synk.meeteam.infra.mail.MailText.MAIL_TITLE_SIGNUP;
 import static synk.meeteam.infra.mail.MailText.MAIL_VERIFY_TEMPLATE;
@@ -74,6 +76,24 @@ public class MailService {
         return templateEngine.process(MAIL_VERIFY_TEMPLATE, context);
     }
 
+    public String generateApplicationNotificationMail(String writerName, String userName, String postId,
+                                                     String postName, String roleName) {
+
+        String logoUrl = LOGO_URL;
+
+        // Thymeleaf context 생성
+        Context context = new Context();
+        context.setVariable("writerName", writerName);
+        context.setVariable("userName", userName);
+        context.setVariable("postName", postName);
+        context.setVariable("postId", postId);
+        context.setVariable("roleName", roleName);
+        context.setVariable("logoUrl", logoUrl);
+
+        // Thymeleaf 템플릿 엔진을 사용하여 변수 값을 주입하여 HTML 렌더링
+        return templateEngine.process(MAIL_APPLICATION_NOTIFICATION_TEMPLATE, context);
+    }
+
     @Async
     @Transactional
     public void sendVerifyMail(String platformId, String receiverMail) {
@@ -110,17 +130,40 @@ public class MailService {
 
         User applicant = recruitmentApplicant.getApplicant();
 
-        String receiverMail =
-                applicant.isUniversityMainEmail() ? applicant.getUniversityEmail() : applicant.getSubEmail();
-
         try {
-            message.addRecipients(RecipientType.TO, receiverMail);// 받는 대상
+            message.addRecipients(RecipientType.TO, applicant.getMainEmail());// 받는 대상
             message.setSubject(MAIL_TITLE_APPROVE);// 제목
 
             String body = generateApproveMailForm(applicant.getName(), postId.toString(),
                     recruitmentApplicant.getRecruitmentPost().getTitle(),
                     recruitmentApplicant.getRole().getName(), writerName,
                     recruitmentApplicant.getRecruitmentPost().getKakaoLink());
+
+            message.setText(body, CHAR_SET, SUB_TYPE);// 내용, charset 타입, subtype
+            // 보내는 사람의 이메일 주소, 보내는 사람 이름
+            message.setFrom(new InternetAddress(SENDER_ADDRESS, SENDER));// 보내는 대상
+            mailSender.send(message); // 메일 전송
+        } catch (Exception e) {
+            log.info("{}", e);
+            throw new AuthException(INVALID_MAIL_SERVICE);
+        }
+
+    }
+
+    @Async
+    @Transactional
+    public void sendApplicationNotificationMail(Long postId, RecruitmentApplicant recruitmentApplicant, User writer) {
+
+        MimeMessage message = mailSender.createMimeMessage();
+        User applicant = recruitmentApplicant.getApplicant();
+
+        try {
+            message.addRecipients(RecipientType.TO, writer.getMainEmail()); // 받는 대상
+            message.setSubject(MAIL_TITLE_APPLICATION);// 제목
+
+            String body = generateApplicationNotificationMail(writer.getName(), applicant.getName(), postId.toString(),
+                    recruitmentApplicant.getRecruitmentPost().getTitle(),
+                    recruitmentApplicant.getRole().getName());
 
             message.setText(body, CHAR_SET, SUB_TYPE);// 내용, charset 타입, subtype
             // 보내는 사람의 이메일 주소, 보내는 사람 이름

--- a/src/main/java/synk/meeteam/infra/mail/MailText.java
+++ b/src/main/java/synk/meeteam/infra/mail/MailText.java
@@ -20,4 +20,8 @@ public class MailText {
     public static final String MAIL_TITLE_APPROVE = "구인 신청 승인";
     public static final String MAIL_APPROVE_TEMPLATE = "ApproveMail";
 
+    // 구인글 신청 알림 관련
+    public static final String MAIL_TITLE_APPLICATION = "구인 신청 알림";
+    public static final String MAIL_APPLICATION_NOTIFICATION_TEMPLATE = "ApplicationNotificationMail";
+
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#307 -> dev
- closed #307 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 구인 신청 시 메일 발송 구현했습니다.
- 깃헙 시크릿값에 메일 폼 넣었습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="944" alt="스크린샷 2024-05-05 오전 1 58 41" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/321d68bb-23ef-4288-9cf6-3b126816bd2c">
* 이름 같은 이유는 로컬에서 했기에 그렇습니다!

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
