### PR TITLE
[FIX] 포트폴리오 삭제로직 수정

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
@@ -1,6 +1,7 @@
 package synk.meeteam.domain.portfolio.portfolio.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.NOT_YOUR_PORTFOLIO;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -25,6 +26,7 @@ import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import synk.meeteam.domain.common.field.entity.Field;
 import synk.meeteam.domain.common.role.entity.Role;
+import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
 import synk.meeteam.global.entity.BaseEntity;
 import synk.meeteam.global.entity.DeleteStatus;
 import synk.meeteam.global.entity.ProceedType;
@@ -147,6 +149,12 @@ public class Portfolio extends BaseEntity {
 
     public boolean isWriter(Long userId) {
         return getCreatedBy().equals(userId);
+    }
+
+    public void validWriter(Long userId) {
+        if (!isWriter(userId)) {
+            throw new PortfolioException(NOT_YOUR_PORTFOLIO);
+        }
     }
 
     public void putPin(int order) {

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/exception/PortfolioExceptionType.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/exception/PortfolioExceptionType.java
@@ -8,7 +8,7 @@ import synk.meeteam.global.common.exception.ExceptionType;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum PortfolioExceptionType implements ExceptionType {
     SS_110(HttpStatus.BAD_REQUEST, "SS-110"),
-    NOT_FOUND_PORTFOLIO(HttpStatus.BAD_REQUEST, "포트폴리오를 찾을 수 없습니다."),
+    NOT_FOUND_PORTFOLIO(HttpStatus.NOT_FOUND, "포트폴리오를 찾을 수 없습니다."),
     OVER_MAX_PIN_SIZE(HttpStatus.BAD_REQUEST, "포트폴리오의 최대 핀 개수를 초과합니다."),
     NOT_YOUR_PORTFOLIO(HttpStatus.FORBIDDEN, "본인의 포트폴리오가 아닙니다.");
 

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -9,21 +9,27 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
+import synk.meeteam.global.entity.DeleteStatus;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, PortfolioCustomRepository {
     List<Portfolio> findAllByCreatedByAndIsPinTrue(Long userId);
 
-    List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(Long id);
+    List<Portfolio> findAllByIsPinTrueAndCreatedByOrderByPinOrderAsc(Long userId);
 
-    @Query("SELECT p FROM Portfolio p LEFT JOIN FETCH p.role LEFT JOIN FETCH p.field where p.id=:id")
-    Optional<Portfolio> findByIdWithFieldAndRole(@Param("id") Long portfolioId);
+    @Query("SELECT p FROM Portfolio p LEFT JOIN FETCH p.role LEFT JOIN FETCH p.field where p.id=:id and p.deleteStatus=:deleteStatus")
+    Optional<Portfolio> findByIdWithFieldAndRoleAndDeleteStatus(@Param("id") Long portfolioId,
+                                                                @Param("deleteStatus") DeleteStatus deleteStatus);
 
-    default Portfolio findByIdOrElseThrow(Long portfolioId) {
-        return findById(portfolioId).orElseThrow(() -> new PortfolioException(NOT_FOUND_PORTFOLIO));
+    Optional<Portfolio> findByIdAndDeleteStatus(Long portfolioId, DeleteStatus deleteStatus);
+
+    default Portfolio findByIdAndAliveOrElseThrow(Long portfolioId) {
+        return findByIdAndDeleteStatus(portfolioId, DeleteStatus.ALIVE).orElseThrow(
+                () -> new PortfolioException(NOT_FOUND_PORTFOLIO));
     }
 
-    default Portfolio findByIdWithFieldAndRoleOrElseThrow(Long portfolioId) {
-        return findByIdWithFieldAndRole(portfolioId).orElseThrow(() -> new PortfolioException(NOT_FOUND_PORTFOLIO));
+    default Portfolio findByIdAndAliveWithFieldAndRoleOrElseThrow(Long portfolioId) {
+        return findByIdWithFieldAndRoleAndDeleteStatus(portfolioId, DeleteStatus.ALIVE).orElseThrow(
+                () -> new PortfolioException(NOT_FOUND_PORTFOLIO));
     }
 
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioFacade.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioFacade.java
@@ -85,9 +85,7 @@ public class PortfolioFacade {
     @Transactional
     public Long editPortfolio(Long portfolioId, User user, UpdatePortfolioRequestDto requestDto) {
         Portfolio portfolio = portfolioService.getPortfolio(portfolioId);
-        if (!portfolio.isWriter(user.getId())) {
-            throw new PortfolioException(NOT_YOUR_PORTFOLIO);
-        }
+        portfolio.validWriter(user.getId());
         portfolioService.editPortfolio(portfolio, user, commandMapper.toUpdatePortfolioCommand(requestDto));
         portfolioSkillService.editPortfolioSkill(portfolio, requestDto.skills());
         portfolioLinkService.editPortfolioLink(portfolio, requestDto.links());

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -1,7 +1,6 @@
 package synk.meeteam.domain.portfolio.portfolio.service;
 
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.NOT_FOUND_PORTFOLIO;
-import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.NOT_YOUR_PORTFOLIO;
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.OVER_MAX_PIN_SIZE;
 import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExceptionType.SS_110;
 
@@ -150,14 +149,11 @@ public class PortfolioServiceImpl implements PortfolioService {
     @Override
     public void deletePortfolio(Long portfolioId, User user) {
         Portfolio portfolio = portfolioRepository.findByIdAndAliveOrElseThrow(portfolioId);
-        if (portfolio.isWriter(user.getId())) {
-            if (portfolio.getIsPin()) {
-                reorderPinPortfolio(user, portfolio);
-            }
-            portfolio.softDelete();
-        } else {
-            throw new PortfolioException(NOT_YOUR_PORTFOLIO);
+        portfolio.validWriter(user.getId());
+        if (portfolio.getIsPin()) {
+            reorderPinPortfolio(user, portfolio);
         }
+        portfolio.softDelete();
     }
 
     private void reorderPinPortfolio(User user, Portfolio portfolio) {


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- hotfix/#330 -> dev
- closed #330

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 기존에 포트폴리오 삭제 이후에도 조회되는 부분을 수정하였습니다.
- 핀 포트폴리오의 경우 삭제 이후 핀 순서를 재정렬해주는 예외처리를 추가하였습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/214ff5e6-1194-4f28-ba14-9d13e55e24dc)

위 처럼 핀 설정 여부와 관계없이 삭제 가능하며, 아래와 같이 조회 시 제공되지 않습니다.
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/c0e65fed-91cc-4494-9947-471b826f3d91)
![image](https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/83166141/97ae6380-aa68-407e-a150-ca525f001061)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
