### PR TITLE
[CHORE] 로그아웃 및 토큰 재발행 로직 수정

### DIFF
--- a/src/main/java/synk/meeteam/infra/redis/repository/RedisTokenRepository.java
+++ b/src/main/java/synk/meeteam/infra/redis/repository/RedisTokenRepository.java
@@ -2,7 +2,6 @@ package synk.meeteam.infra.redis.repository;
 
 import static synk.meeteam.domain.auth.exception.AuthExceptionType.NOT_FOUND_REFRESH_TOKEN;
 
-import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import synk.meeteam.domain.auth.exception.AuthException;
@@ -11,12 +10,9 @@ import synk.meeteam.security.jwt.service.vo.TokenVO;
 
 @Repository
 public interface RedisTokenRepository extends CrudRepository<TokenVO, String> {
-    Optional<TokenVO> findByPlatformId(String platformId);
-
-    default TokenVO findByPlatformIdOrElseThrowException(String platformId) {
-        return findByPlatformId(platformId)
+    default TokenVO findByIdOrElseThrow(String userId) {
+        return findById(userId)
                 .filter(tokenVO -> !tokenVO.isBlack())
-                .orElseThrow(
-                        () -> new AuthException(NOT_FOUND_REFRESH_TOKEN));
+                .orElseThrow(() -> new AuthException(NOT_FOUND_REFRESH_TOKEN));
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#335 -> dev
- closed #335 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 로그아웃 및 토큰 재발행 로직에서 플랫폼 id -> userId로 변경했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
### 로그아웃
<img width="868" alt="스크린샷 2024-05-08 오후 10 44 30" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/5b532b04-f7dc-430f-b69b-b873bc5bc0a5">

### 토큰 재발행
<img width="899" alt="스크린샷 2024-05-08 오후 10 50 26" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/7046b805-d5ae-4a18-819f-3e932aa037e6">


### 이미 해당 토큰으로 재발행한 경우
<img width="885" alt="스크린샷 2024-05-08 오후 10 49 56" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/2e01165e-f1f8-4119-8efa-ccb9f3322339">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
