### PR TITLE
[FIX] content에 한해 이스케이핑 적용 해제

### DIFF
--- a/src/main/java/synk/meeteam/global/util/UnescapedFieldSerializer.java
+++ b/src/main/java/synk/meeteam/global/util/UnescapedFieldSerializer.java
@@ -1,18 +1,22 @@
 package synk.meeteam.global.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class UnescapedFieldSerializer extends JsonSerializer<String> {
+
 
     @Override
     public void serialize(String value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        // HTML escaping을 하지 않고 그대로 출력
-        gen.writeRawValue("\"" + value + "\"");
+        // 구인글 "content"에 한해서 escape 하지 않고 그대로 출력
+        // 잠시 이스케이핑 설정을 on/off 하는 방식
+        CharacterEscapes characterEscapes = gen.getCharacterEscapes();
+        gen.setCharacterEscapes(null);
+        gen.writeString(value);
+        gen.setCharacterEscapes(characterEscapes);
     }
 }
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#342 -> dev
- closed #342 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 프론트에서 받을 때, Object가 아닌 String으로 받게 되는 문제가 발생했습니다.
- 정확한 원인인지는 모르겠지만 시점을 생각해봤을 때, RawValue로 저장하도록 코드 변경 후 부터 에러가 발생했다고 생각했습니다.
- 그래서 "content" 변수도 String으로 저장하되, String으로 저장하기 전에 이스케이핑 설정을 초기화 시켜두고, 저장 후에 다시 적용하는 방식으로 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
- 프론트에서 테스트를 해봐야 할 것 같습니다..! 로컬에서는 정확하게 에러탐지가 어렵네요..

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
