### PR TITLE
[FIX] 구인글 검색 API total count 버그 수정

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
@@ -104,7 +104,8 @@ public class RecruitmentPostSearchRepositoryImpl implements RecruitmentPostSearc
                         writerUniversityEq(writer, userDomain, condition.getScope()),
                         categoryEq(condition.getCategory()),
                         titleContains(keyword),
-                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED)
+                        recruitmentPost.deleteStatus.ne(DeleteStatus.DELETED),
+                        recruitmentPost.isClosed.isFalse()
                 );
 
         searchJpaUtils.joinWithFieldAndTagAndRoleAndSkill(countQuery, condition);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- hotfix/#345 -> dev
- closed #345

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 구인글 검색 시에 total count가 잘못나오는 오류가 있어 수정했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
