### PR TITLE
[FEAT] 내 프로필 이미지 조회 기능 구현

### DIFF
--- a/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResponseDto;
 import synk.meeteam.domain.user.user.dto.request.UpdateProfileRequestDto;
 import synk.meeteam.domain.user.user.dto.response.CheckDuplicateNicknameResponseDto;
+import synk.meeteam.domain.user.user.dto.response.GetProfileImageResponseDto;
 import synk.meeteam.domain.user.user.dto.response.GetProfileResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.global.common.exception.ExceptionResponse;
@@ -66,4 +67,8 @@ public interface UserApi {
     ResponseEntity<GetUserPortfolioResponseDto> getUserPortfolio(@AuthUser User user,
                                                                  @RequestParam(name = "page", defaultValue = "1") int page,
                                                                  @RequestParam(name = "size", defaultValue = "12") int size);
+
+    @Operation(summary = "내 프로필 사진 조회 API")
+    @SecurityRequirement(name = "Authorization")
+    ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -1,5 +1,7 @@
 package synk.meeteam.domain.user.user.api;
 
+import static synk.meeteam.infra.s3.S3FileName.USER;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +16,13 @@ import synk.meeteam.domain.portfolio.portfolio.dto.response.GetUserPortfolioResp
 import synk.meeteam.domain.portfolio.portfolio.service.PortfolioService;
 import synk.meeteam.domain.user.user.dto.request.UpdateProfileRequestDto;
 import synk.meeteam.domain.user.user.dto.response.CheckDuplicateNicknameResponseDto;
+import synk.meeteam.domain.user.user.dto.response.GetProfileImageResponseDto;
 import synk.meeteam.domain.user.user.dto.response.GetProfileResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.ProfileFacade;
 import synk.meeteam.domain.user.user.service.UserService;
 import synk.meeteam.global.util.Encryption;
+import synk.meeteam.infra.s3.service.S3Service;
 import synk.meeteam.security.AuthUser;
 
 @RestController
@@ -28,6 +32,8 @@ public class UserController implements UserApi {
 
     private final UserService userService;
     private final PortfolioService portfolioService;
+    private final S3Service s3Service;
+
     private final ProfileFacade profileFacade;
 
     @Override
@@ -68,5 +74,12 @@ public class UserController implements UserApi {
             @AuthUser User user, @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "12") int size) {
         return ResponseEntity.ok(portfolioService.getSliceMyAllPortfolio(page, size, user));
+    }
+
+    @Override
+    @GetMapping("/profile/me")
+    public ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user) {
+        String profileImgUrl = s3Service.createPreSignedGetUrl(USER, user.getProfileImgFileName());
+        return ResponseEntity.ok(GetProfileImageResponseDto.of(profileImgUrl));
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -77,7 +77,7 @@ public class UserController implements UserApi {
     }
 
     @Override
-    @GetMapping("/profile/me")
+    @GetMapping("/profile/image")
     public ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user) {
         String profileImgUrl = s3Service.createPreSignedGetUrl(USER, user.getProfileImgFileName());
         return ResponseEntity.ok(GetProfileImageResponseDto.of(profileImgUrl));

--- a/src/main/java/synk/meeteam/domain/user/user/dto/response/GetProfileImageResponseDto.java
+++ b/src/main/java/synk/meeteam/domain/user/user/dto/response/GetProfileImageResponseDto.java
@@ -1,0 +1,12 @@
+package synk.meeteam.domain.user.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetProfileImageResponseDto(
+        @Schema(description = "프로필 이미지 url", example = "https://image.png")
+        String imageUrl
+) {
+        public static GetProfileImageResponseDto of(String imageUrl){
+                return new GetProfileImageResponseDto(imageUrl);
+        }
+}

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserServiceImpl.java
@@ -22,7 +22,6 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
-    private final ProfileMapper profileMapper;
 
     @Transactional(readOnly = true)
     public boolean checkAvailableNickname(String nickname) {


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#337 -> dev
- closed #337 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 내 프로필 이미지 조회 기능 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="870" alt="스크린샷 2024-05-13 오후 8 16 33" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/fa7de538-e9b8-4318-8bae-dbd6ec6f2caf">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
