### PR TITLE
[FEAT] 회원 탈퇴 구현

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -36,7 +36,7 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, Por
 
     List<Portfolio> findAllByCreatedBy(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM Portfolio p WHERE p.id IN :portfolioIds")
     void deleteAllByIdsInQuery(List<Long> portfolioIds);

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -5,8 +5,10 @@ import static synk.meeteam.domain.portfolio.portfolio.exception.PortfolioExcepti
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio.exception.PortfolioException;
 import synk.meeteam.global.entity.DeleteStatus;
@@ -33,5 +35,10 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, Por
     }
 
     List<Portfolio> findAllByCreatedBy(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Portfolio p WHERE p.id IN :portfolioIds")
+    void deleteAllByIdsInQuery(List<Long> portfolioIds);
 
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioRepository.java
@@ -32,4 +32,6 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long>, Por
                 () -> new PortfolioException(NOT_FOUND_PORTFOLIO));
     }
 
+    List<Portfolio> findAllByCreatedBy(Long userId);
+
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio_link/repository/PortfolioLinkRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio_link/repository/PortfolioLinkRepository.java
@@ -13,7 +13,7 @@ public interface PortfolioLinkRepository extends JpaRepository<PortfolioLink, Lo
 
     void deleteAllByPortfolio(Portfolio portfolio);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM PortfolioLink p WHERE p.portfolio.id IN :portfolioIds")
     void deleteAllByPortfolioIdsInQuery(List<Long> portfolioIds);

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio_link/repository/PortfolioLinkRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio_link/repository/PortfolioLinkRepository.java
@@ -2,6 +2,9 @@ package synk.meeteam.domain.portfolio.portfolio_link.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio_link.entity.PortfolioLink;
 
@@ -9,4 +12,9 @@ public interface PortfolioLinkRepository extends JpaRepository<PortfolioLink, Lo
     List<PortfolioLink> findAllByPortfolio(Portfolio portfolio);
 
     void deleteAllByPortfolio(Portfolio portfolio);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PortfolioLink p WHERE p.portfolio.id IN :portfolioIds")
+    void deleteAllByPortfolioIdsInQuery(List<Long> portfolioIds);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio_skill/repository/PortfolioSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio_skill/repository/PortfolioSkillRepository.java
@@ -2,8 +2,10 @@ package synk.meeteam.domain.portfolio.portfolio_skill.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
 import synk.meeteam.domain.portfolio.portfolio_skill.entity.PortfolioSkill;
 
@@ -12,4 +14,9 @@ public interface PortfolioSkillRepository extends JpaRepository<PortfolioSkill, 
     List<PortfolioSkill> findAllByPortfolioWithSkill(@Param("portfolio") Portfolio portfolio);
 
     void deleteAllByPortfolio(Portfolio portfolio);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PortfolioSkill p WHERE p.portfolio.id IN :portfolioIds")
+    void deleteAllByPortfolioIdsInQuery(List<Long> portfolioIds);
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio_skill/repository/PortfolioSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio_skill/repository/PortfolioSkillRepository.java
@@ -15,7 +15,7 @@ public interface PortfolioSkillRepository extends JpaRepository<PortfolioSkill, 
 
     void deleteAllByPortfolio(Portfolio portfolio);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM PortfolioSkill p WHERE p.portfolio.id IN :portfolioIds")
     void deleteAllByPortfolioIdsInQuery(List<Long> portfolioIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
@@ -10,4 +10,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByRecruitmentPostAndUser(RecruitmentPost recruitmentPost, User user);
 
     void deleteByRecruitmentPostAndUser(RecruitmentPost recruitmentPost, User user);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
@@ -15,7 +15,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     void deleteByRecruitmentPostAndUser(RecruitmentPost recruitmentPost, User user);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM Bookmark b WHERE b.user.id = :userId")
     void deleteAllByUserId(Long userId);

--- a/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
@@ -1,7 +1,11 @@
 package synk.meeteam.domain.recruitment.bookmark.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.bookmark.entity.Bookmark;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.user.user.entity.User;
@@ -11,5 +15,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     void deleteByRecruitmentPostAndUser(RecruitmentPost recruitmentPost, User user);
 
-    void deleteAllByUser(User user);
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Bookmark b WHERE b.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -5,8 +5,10 @@ import static synk.meeteam.domain.recruitment.recruitment_applicant.exception.Re
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.global.entity.DeleteStatus;
 import synk.meeteam.domain.recruitment.recruitment_applicant.entity.RecruitmentApplicant;
 import synk.meeteam.domain.recruitment.recruitment_applicant.exception.RecruitmentApplicantException;
@@ -28,6 +30,8 @@ public interface RecruitmentApplicantRepository extends JpaRepository<Recruitmen
         return findByRecruitmentPostAndApplicantAndDeleteStatus(recruitmentPost, user, DeleteStatus.ALIVE)
                 .orElseThrow(() -> new RecruitmentApplicantException(SS_600));
     }
-
-    void deleteAllByRecruitmentPost(RecruitmentPost recruitmentPost);
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RecruitmentApplicant r WHERE r.recruitmentPost.id IN :postIds")
+    void deleteAllByPostIdInQuery(List<Long> postIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -28,4 +28,6 @@ public interface RecruitmentApplicantRepository extends JpaRepository<Recruitmen
         return findByRecruitmentPostAndApplicantAndDeleteStatus(recruitmentPost, user, DeleteStatus.ALIVE)
                 .orElseThrow(() -> new RecruitmentApplicantException(SS_600));
     }
+
+    void deleteAllByRecruitmentPost(RecruitmentPost recruitmentPost);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -30,7 +30,7 @@ public interface RecruitmentApplicantRepository extends JpaRepository<Recruitmen
         return findByRecruitmentPostAndApplicantAndDeleteStatus(recruitmentPost, user, DeleteStatus.ALIVE)
                 .orElseThrow(() -> new RecruitmentApplicantException(SS_600));
     }
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM RecruitmentApplicant r WHERE r.recruitmentPost.id IN :postIds")
     void deleteAllByPostIdInQuery(List<Long> postIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -30,7 +30,7 @@ public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentC
         return findById(commentId).orElseThrow(() -> new RecruitmentCommentException(INVALID_COMMENT));
     }
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM RecruitmentComment r WHERE r.recruitmentPost.id IN :postIds")
     void deleteAllByPostIdInQuery(List<Long> postIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -25,4 +25,6 @@ public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentC
     default RecruitmentComment findByIdOrElseThrow(Long commentId) {
         return findById(commentId).orElseThrow(() -> new RecruitmentCommentException(INVALID_COMMENT));
     }
+
+    void deleteAllByRecruitmentPost(RecruitmentPost recruitmentPost);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepository.java
@@ -2,8 +2,12 @@ package synk.meeteam.domain.recruitment.recruitment_comment.repository;
 
 import static synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentExceptionType.INVALID_COMMENT;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_comment.entity.RecruitmentComment;
 import synk.meeteam.domain.recruitment.recruitment_comment.exception.RecruitmentCommentException;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
@@ -26,5 +30,8 @@ public interface RecruitmentCommentRepository extends JpaRepository<RecruitmentC
         return findById(commentId).orElseThrow(() -> new RecruitmentCommentException(INVALID_COMMENT));
     }
 
-    void deleteAllByRecruitmentPost(RecruitmentPost recruitmentPost);
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RecruitmentComment r WHERE r.recruitmentPost.id IN :postIds")
+    void deleteAllByPostIdInQuery(List<Long> postIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
@@ -5,8 +5,10 @@ import static synk.meeteam.domain.recruitment.recruitment_post.exception.Recruit
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_post.exception.RecruitmentPostException;
 
@@ -21,4 +23,9 @@ public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost
     }
 
     List<RecruitmentPost> findAllByCreatedBy(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RecruitmentPost r WHERE r.id IN :postIds")
+    void deleteAllByIdInQuery(List<Long> postIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
@@ -2,6 +2,7 @@ package synk.meeteam.domain.recruitment.recruitment_post.repository;
 
 import static synk.meeteam.domain.recruitment.recruitment_post.exception.RecruitmentPostExceptionType.NOT_FOUND_POST;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,6 @@ public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost
     default RecruitmentPost findByIdOrElseThrow(Long postId) {
         return findByIdAndDeleteStatus(postId).orElseThrow(() -> new RecruitmentPostException(NOT_FOUND_POST));
     }
+
+    List<RecruitmentPost> findAllByCreatedBy(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostRepository.java
@@ -24,7 +24,7 @@ public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost
 
     List<RecruitmentPost> findAllByCreatedBy(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM RecruitmentPost r WHERE r.id IN :postIds")
     void deleteAllByIdInQuery(List<Long> postIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
@@ -6,8 +6,10 @@ import static synk.meeteam.domain.recruitment.recruitment_role.exception.Recruit
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.common.role.entity.Role;
 import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
 import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
@@ -30,6 +32,12 @@ public interface RecruitmentRoleRepository extends JpaRepository<RecruitmentRole
     }
 
     void deleteAllByRecruitmentPostId(Long postId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RecruitmentRole r WHERE r.recruitmentPost.id IN :postIds")
+    void deleteAllByPostIdInQuery(List<Long> postIds);
+
 
     @Query("SELECT r FROM RecruitmentRole r JOIN FETCH r.recruitmentPost p JOIN FETCH r.role t WHERE p.id = :postId AND t.id IN :roleIds")
     List<RecruitmentRole> findAllByPostIdAndRoleIds(@Param("postId") Long postId, @Param("roleIds") List<Long> roleIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role/repository/RecruitmentRoleRepository.java
@@ -33,7 +33,7 @@ public interface RecruitmentRoleRepository extends JpaRepository<RecruitmentRole
 
     void deleteAllByRecruitmentPostId(Long postId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM RecruitmentRole r WHERE r.recruitmentPost.id IN :postIds")
     void deleteAllByPostIdInQuery(List<Long> postIds);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/repository/RecruitmentRoleSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_role_skill/repository/RecruitmentRoleSkillRepository.java
@@ -11,7 +11,7 @@ import synk.meeteam.domain.recruitment.recruitment_role_skill.entity.Recruitment
 public interface RecruitmentRoleSkillRepository extends JpaRepository<RecruitmentRoleSkill, Long> {
 
     @Transactional
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from RecruitmentRoleSkill r where r.recruitmentRole.id in :recruitmentRoleIds")
     void deleteAllByRecruitmentRoleIdInQuery(@Param("recruitmentRoleIds") List<Long> recruitmentRoleIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
@@ -2,8 +2,10 @@ package synk.meeteam.domain.recruitment.recruitment_tag.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.recruitment.recruitment_tag.entity.RecruitmentTag;
 
 public interface RecruitmentTagRepository extends JpaRepository<RecruitmentTag, Long> {
@@ -11,4 +13,9 @@ public interface RecruitmentTagRepository extends JpaRepository<RecruitmentTag, 
     List<RecruitmentTag> findByPostIdWithTag(@Param("postId") Long postId);
 
     void deleteAllByRecruitmentPostId(Long postId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RecruitmentTag r WHERE r.recruitmentPost.id IN :postIds")
+    void deleteAllByPostIdInQuery(List<Long> postIds);
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_tag/repository/RecruitmentTagRepository.java
@@ -14,7 +14,7 @@ public interface RecruitmentTagRepository extends JpaRepository<RecruitmentTag, 
 
     void deleteAllByRecruitmentPostId(Long postId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM RecruitmentTag r WHERE r.recruitmentPost.id IN :postIds")
     void deleteAllByPostIdInQuery(List<Long> postIds);

--- a/src/main/java/synk/meeteam/domain/user/award/repository/AwardRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/award/repository/AwardRepository.java
@@ -13,7 +13,7 @@ public interface AwardRepository extends JpaRepository<Award, Long> {
 
     List<Award> findAllByCreatedBy(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM Award a WHERE a.createdBy = :userId")
     void deleteAllByUserId(Long userId);

--- a/src/main/java/synk/meeteam/domain/user/award/repository/AwardRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/award/repository/AwardRepository.java
@@ -2,6 +2,9 @@ package synk.meeteam.domain.user.award.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.user.award.entity.Award;
 
 public interface AwardRepository extends JpaRepository<Award, Long> {
@@ -9,4 +12,9 @@ public interface AwardRepository extends JpaRepository<Award, Long> {
     void deleteAllByCreatedBy(Long userId);
 
     List<Award> findAllByCreatedBy(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Award a WHERE a.createdBy = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserApi.java
@@ -71,4 +71,8 @@ public interface UserApi {
     @Operation(summary = "내 프로필 사진 조회 API")
     @SecurityRequirement(name = "Authorization")
     ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user);
+
+    @Operation(summary = "회원 탈퇴 API")
+    @SecurityRequirement(name = "Authorization")
+    ResponseEntity<Void> deleteUser(@AuthUser User user);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -5,6 +5,7 @@ import static synk.meeteam.infra.s3.S3FileName.USER;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,6 +21,7 @@ import synk.meeteam.domain.user.user.dto.response.GetProfileImageResponseDto;
 import synk.meeteam.domain.user.user.dto.response.GetProfileResponseDto;
 import synk.meeteam.domain.user.user.entity.User;
 import synk.meeteam.domain.user.user.service.ProfileFacade;
+import synk.meeteam.domain.user.user.service.UserManagementService;
 import synk.meeteam.domain.user.user.service.UserService;
 import synk.meeteam.global.util.Encryption;
 import synk.meeteam.infra.s3.service.S3Service;
@@ -35,6 +37,7 @@ public class UserController implements UserApi {
     private final S3Service s3Service;
 
     private final ProfileFacade profileFacade;
+    private final UserManagementService userManagementService;
 
     @Override
     @PutMapping("/profile")
@@ -53,7 +56,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok(profileFacade.readProfile(user, userId));
     }
 
-    @GetMapping("encrypt/{userId}")
+    @GetMapping("/encrypt/{userId}")
     public ResponseEntity<String> getEncryptedId(@PathVariable("userId") Long userId) {
         return ResponseEntity.ok(Encryption.encryptLong(userId));
     }
@@ -81,5 +84,13 @@ public class UserController implements UserApi {
     public ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user) {
         String profileImgUrl = s3Service.createPreSignedGetUrl(USER, user.getProfileImgFileName());
         return ResponseEntity.ok(GetProfileImageResponseDto.of(profileImgUrl));
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@AuthUser User user) {
+        userManagementService.deleteUser(user);
+
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
@@ -1,0 +1,90 @@
+package synk.meeteam.domain.user.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
+import synk.meeteam.domain.portfolio.portfolio.repository.PortfolioRepository;
+import synk.meeteam.domain.portfolio.portfolio_link.repository.PortfolioLinkRepository;
+import synk.meeteam.domain.portfolio.portfolio_skill.repository.PortfolioSkillRepository;
+import synk.meeteam.domain.recruitment.bookmark.repository.BookmarkRepository;
+import synk.meeteam.domain.recruitment.recruitment_applicant.repository.RecruitmentApplicantRepository;
+import synk.meeteam.domain.recruitment.recruitment_comment.repository.RecruitmentCommentRepository;
+import synk.meeteam.domain.recruitment.recruitment_post.entity.RecruitmentPost;
+import synk.meeteam.domain.recruitment.recruitment_post.repository.RecruitmentPostRepository;
+import synk.meeteam.domain.recruitment.recruitment_role.entity.RecruitmentRole;
+import synk.meeteam.domain.recruitment.recruitment_role.repository.RecruitmentRoleRepository;
+import synk.meeteam.domain.recruitment.recruitment_role_skill.repository.RecruitmentRoleSkillRepository;
+import synk.meeteam.domain.recruitment.recruitment_tag.repository.RecruitmentTagRepository;
+import synk.meeteam.domain.user.award.repository.AwardRepository;
+import synk.meeteam.domain.user.user.entity.User;
+import synk.meeteam.domain.user.user.repository.UserRepository;
+import synk.meeteam.domain.user.user_link.repository.UserLinkRepository;
+import synk.meeteam.domain.user.user_skill.repository.UserSkillRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserManagementService {
+
+    // 유저 관련
+    private final UserRepository userRepository;
+    private final UserSkillRepository userSkillRepository;
+    private final UserLinkRepository userLinkRepository;
+    private final AwardRepository awardRepository;
+
+    // 포토폴리오 관련
+    private final PortfolioRepository portfolioRepository;
+    private final PortfolioSkillRepository portfolioSkillRepository;
+    private final PortfolioLinkRepository portfolioLinkRepository;
+
+    // 구인 관련
+    private final RecruitmentPostRepository recruitmentPostRepository;
+    private final RecruitmentRoleRepository recruitmentRoleRepository;
+    private final RecruitmentRoleSkillRepository recruitmentRoleSkillRepository;
+    private final RecruitmentTagRepository recruitmentTagRepository;
+    private final RecruitmentCommentRepository recruitmentCommentRepository;
+    private final RecruitmentApplicantRepository recruitmentApplicantRepository;
+
+    // 기타
+    private final BookmarkRepository bookmarkRepository;
+
+    @Transactional
+    public void deleteUser(User user) {
+        recruitmentPostRepository.findAllByCreatedBy(user.getId())
+                .forEach(this::deleteRecruitmentPost);
+
+        portfolioRepository.findAllByCreatedBy(user.getId())
+                .forEach(portfolio -> deletePortfolio(portfolio, user));
+
+        deleteProfile(user);
+
+        userRepository.delete(user);
+    }
+
+    private void deleteRecruitmentPost(RecruitmentPost recruitmentPost) {
+        List<Long> recruitmentRoleIds = recruitmentRoleRepository.findByPostIdWithSkills(
+                recruitmentPost.getId()).stream()
+                .map(RecruitmentRole::getId).toList();
+
+        recruitmentRoleSkillRepository.deleteAllByRecruitmentRoleIdInQuery(recruitmentRoleIds);
+        recruitmentRoleRepository.deleteAllByRecruitmentPostId(recruitmentPost.getId());
+        recruitmentTagRepository.deleteAllByRecruitmentPostId(recruitmentPost.getId());
+        recruitmentCommentRepository.deleteAllByRecruitmentPost(recruitmentPost);
+        recruitmentApplicantRepository.deleteAllByRecruitmentPost(recruitmentPost);
+        recruitmentPostRepository.delete(recruitmentPost);
+    }
+
+    private void deletePortfolio(Portfolio portfolio, User user){
+        portfolioSkillRepository.deleteAllByPortfolio(portfolio);
+        portfolioLinkRepository.deleteAllByPortfolio(portfolio);
+        awardRepository.deleteAllByCreatedBy(user.getId());
+        bookmarkRepository.deleteAllByUser(user);
+        portfolioRepository.delete(portfolio);
+    }
+
+    private void deleteProfile(User user){
+        userSkillRepository.deleteAllByCreatedBy(user.getId());
+        userLinkRepository.deleteAllByCreatedBy(user.getId());
+    }
+}

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
@@ -53,9 +53,10 @@ public class UserManagementService {
     public void deleteUser(User user) {
         recruitmentPostRepository.findAllByCreatedBy(user.getId())
                 .forEach(this::deleteRecruitmentPost);
+        bookmarkRepository.deleteAllByUser(user);
 
         portfolioRepository.findAllByCreatedBy(user.getId())
-                .forEach(portfolio -> deletePortfolio(portfolio, user));
+                .forEach(portfolio -> deletePortfolio(portfolio));
 
         deleteProfile(user);
 
@@ -73,18 +74,18 @@ public class UserManagementService {
         recruitmentCommentRepository.deleteAllByRecruitmentPost(recruitmentPost);
         recruitmentApplicantRepository.deleteAllByRecruitmentPost(recruitmentPost);
         recruitmentPostRepository.delete(recruitmentPost);
+
     }
 
-    private void deletePortfolio(Portfolio portfolio, User user){
+    private void deletePortfolio(Portfolio portfolio){
         portfolioSkillRepository.deleteAllByPortfolio(portfolio);
         portfolioLinkRepository.deleteAllByPortfolio(portfolio);
-        awardRepository.deleteAllByCreatedBy(user.getId());
-        bookmarkRepository.deleteAllByUser(user);
         portfolioRepository.delete(portfolio);
     }
 
     private void deleteProfile(User user){
         userSkillRepository.deleteAllByCreatedBy(user.getId());
         userLinkRepository.deleteAllByCreatedBy(user.getId());
+        awardRepository.deleteAllByCreatedBy(user.getId());
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
@@ -51,41 +51,38 @@ public class UserManagementService {
 
     @Transactional
     public void deleteUser(User user) {
-        recruitmentPostRepository.findAllByCreatedBy(user.getId())
-                .forEach(this::deleteRecruitmentPost);
-        bookmarkRepository.deleteAllByUser(user);
+        List<Long> postIds = recruitmentPostRepository.findAllByCreatedBy(user.getId()).stream()
+                .map(RecruitmentPost::getId).toList();
+        deleteRecruitmentPosts(postIds, user.getId());
 
-        portfolioRepository.findAllByCreatedBy(user.getId())
-                .forEach(portfolio -> deletePortfolio(portfolio));
+        List<Long> portfolioIds = portfolioRepository.findAllByCreatedBy(user.getId())
+                .stream().map(Portfolio::getId).toList();
+        deletePortfolios(portfolioIds);
 
-        deleteProfile(user);
+        deleteProfile(user.getId());
 
         userRepository.delete(user);
     }
 
-    private void deleteRecruitmentPost(RecruitmentPost recruitmentPost) {
-        List<Long> recruitmentRoleIds = recruitmentRoleRepository.findByPostIdWithSkills(
-                recruitmentPost.getId()).stream()
-                .map(RecruitmentRole::getId).toList();
+    private void deleteRecruitmentPosts(List<Long> postIds, Long userId) {
 
-        recruitmentRoleSkillRepository.deleteAllByRecruitmentRoleIdInQuery(recruitmentRoleIds);
-        recruitmentRoleRepository.deleteAllByRecruitmentPostId(recruitmentPost.getId());
-        recruitmentTagRepository.deleteAllByRecruitmentPostId(recruitmentPost.getId());
-        recruitmentCommentRepository.deleteAllByRecruitmentPost(recruitmentPost);
-        recruitmentApplicantRepository.deleteAllByRecruitmentPost(recruitmentPost);
-        recruitmentPostRepository.delete(recruitmentPost);
-
+        bookmarkRepository.deleteAllByUserId(userId);
+        recruitmentRoleRepository.deleteAllByPostIdInQuery(postIds);
+        recruitmentTagRepository.deleteAllByPostIdInQuery(postIds);
+        recruitmentCommentRepository.deleteAllByPostIdInQuery(postIds);
+        recruitmentApplicantRepository.deleteAllByPostIdInQuery(postIds);
+        recruitmentPostRepository.deleteAllByIdInQuery(postIds);
     }
 
-    private void deletePortfolio(Portfolio portfolio){
-        portfolioSkillRepository.deleteAllByPortfolio(portfolio);
-        portfolioLinkRepository.deleteAllByPortfolio(portfolio);
-        portfolioRepository.delete(portfolio);
+    private void deletePortfolios(List<Long> portfolioIds) {
+        portfolioSkillRepository.deleteAllByPortfolioIdsInQuery(portfolioIds);
+        portfolioLinkRepository.deleteAllByPortfolioIdsInQuery(portfolioIds);
+        portfolioRepository.deleteAllByIdsInQuery(portfolioIds);
     }
 
-    private void deleteProfile(User user){
-        userSkillRepository.deleteAllByCreatedBy(user.getId());
-        userLinkRepository.deleteAllByCreatedBy(user.getId());
-        awardRepository.deleteAllByCreatedBy(user.getId());
+    private void deleteProfile(Long userId) {
+        userSkillRepository.deleteAllByUserId(userId);
+        userLinkRepository.deleteAllByUserId(userId);
+        awardRepository.deleteAllByUserId(userId);
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user_link/repository/UserLinkRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/user_link/repository/UserLinkRepository.java
@@ -13,7 +13,7 @@ public interface UserLinkRepository extends JpaRepository<UserLink, Long> {
 
     List<UserLink> findAllByCreatedBy(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM UserLink u WHERE u.createdBy = :userId")
     void deleteAllByUserId(Long userId);

--- a/src/main/java/synk/meeteam/domain/user/user_link/repository/UserLinkRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/user_link/repository/UserLinkRepository.java
@@ -2,6 +2,9 @@ package synk.meeteam.domain.user.user_link.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.user.user_link.entity.UserLink;
 
 public interface UserLinkRepository extends JpaRepository<UserLink, Long> {
@@ -9,4 +12,9 @@ public interface UserLinkRepository extends JpaRepository<UserLink, Long> {
     void deleteAllByCreatedBy(Long userId);
 
     List<UserLink> findAllByCreatedBy(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserLink u WHERE u.createdBy = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/user/user_skill/repository/UserSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/user_skill/repository/UserSkillRepository.java
@@ -11,7 +11,7 @@ public interface UserSkillRepository extends JpaRepository<UserSkill, Long>, Use
 
     void deleteAllByCreatedBy(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Transactional
     @Query("DELETE FROM UserSkill u WHERE u.createdBy = :userId")
     void deleteAllByUserId(Long userId);

--- a/src/main/java/synk/meeteam/domain/user/user_skill/repository/UserSkillRepository.java
+++ b/src/main/java/synk/meeteam/domain/user/user_skill/repository/UserSkillRepository.java
@@ -1,9 +1,18 @@
 package synk.meeteam.domain.user.user_skill.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import synk.meeteam.domain.user.user_skill.entity.UserSkill;
 
 public interface UserSkillRepository extends JpaRepository<UserSkill, Long>, UserSkillCustomRepository {
 
     void deleteAllByCreatedBy(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM UserSkill u WHERE u.createdBy = :userId")
+    void deleteAllByUserId(Long userId);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 회원 탈퇴 구현했습니다.
- 처음에는 CASCADE 옵션을 사용해서 구현하려고 했습니다.
- 하지만 다음과 같은 생각이 들었는데요!

1. `CASCADE`의 위험성 : 개인적으로 `CASCADE` 옵션이 매우 위험한 옵션이라고 생각했습니다! 물론 저희가 잘 신경쓰면 괜찮을 수 있습니다. 하지만 그럼에도 불구하고, 개발자가 의도하지 않은 데이터가 사라질 수 있다는 가능성이 있다는 점이 개인적으로 좋지 않다고 생각했습니다. 만약 휴먼 에러로 잘못된 설정을 한다면, 잘못하면 가장 중요한 DB가 다 날라갈 수도 있겠다라는 생각이 들었습니다! 개인적으로 저는 db에 hard delete를 할 경우, 사라지는 모든 데이터를 개발자가 명시적으로 의도했음 좋겠다고 생각합니다!

2. `CASCADE`의 범위 설정 : 그럼에도 불구하고, `CASCADE` 를 사용할 경우 구인글에 적용했다고 가정해보겠습니다. 그렇게 되면 구인 관련된 것은 사라지겠지만, 외부키로 설정된 Tag나 role 부분도 삭제될 수 있겠다고 생각이 들었습니다. 이 부분은 정확하지 않거나 제가 방법을 모르는 것 일 수도 있습니다! 아무튼 그런 이유 때문에도 사용이 꺼려졌습니다!

3. 성능 이슈 : 이렇게 되면 가장 큰 trade-off 가 DB I/O가 증가한다는 것입니다. 사실 CASCADE 연산과 여러번 delete 연산의 차이가 어느정도 일지는 아직 검증이 안되어 있습니다. 그럼에도 불구하고, 여러번 delete 연산이 훨씬 더 느릴 가능성은 있다고 생각이 들었습니다. 하지만 저는 개인적으로 모든 API의 성능을 고려하는 것도 비용이라고 생각합니다. 회원탈퇴라는 기능을 고려해봤을 때, 굳이 성능 고민이 필요없다고 생각했습니다! 정말 성능에 이슈가 있다면, 나중에 메세지큐를 도입하는 것도 방법일 것 같습니다!

4. 코드의 복잡함? : 회원탈퇴도 사실 비즈니스 로직이라고 할 수 있을 것 같지만 수동 삭제를 하게 될 경우 기존 서비스 로직이 많이 더러워질 수도 있겠다고 생각했습니다. 일반적인 비즈니스 로직과 성격이 다르다고 생각하기도 해서 일부러 서비스 클래스를 따로 만들었습니다! 이에 대한 의견도 궁금합니다!


참고자료 : 
https://www.inflearn.com/questions/652184/jpa-%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84-%EC%A7%88%EB%AC%B8%EC%9E%85%EB%8B%88%EB%8B%A4
https://tecoble.techcourse.co.kr/post/2023-08-14-JPA-Cascade/

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#349 -> dev
- closed #349 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
