### PR TITLE
[FIX] 삭제하려는 구인글 북마크 이력 삭제 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/bookmark/repository/BookmarkRepository.java
@@ -19,4 +19,9 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Transactional
     @Query("DELETE FROM Bookmark b WHERE b.user.id = :userId")
     void deleteAllByUserId(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Bookmark b WHERE b.recruitmentPost.id IN :postIds")
+    void deleteAllByPostIdInQuery(List<Long> postIds);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
@@ -53,7 +53,7 @@ public class UserManagementService {
     public void deleteUser(User user) {
         List<Long> postIds = recruitmentPostRepository.findAllByCreatedBy(user.getId()).stream()
                 .map(RecruitmentPost::getId).toList();
-        deleteRecruitmentPosts(postIds, user.getId());
+        deleteRecruitmentPosts(postIds);
 
         List<Long> portfolioIds = portfolioRepository.findAllByCreatedBy(user.getId())
                 .stream().map(Portfolio::getId).toList();
@@ -64,9 +64,8 @@ public class UserManagementService {
         userRepository.delete(user);
     }
 
-    private void deleteRecruitmentPosts(List<Long> postIds, Long userId) {
-
-        bookmarkRepository.deleteAllByUserId(userId);
+    private void deleteRecruitmentPosts(List<Long> postIds) {
+        bookmarkRepository.deleteAllByPostIdInQuery(postIds);
         recruitmentRoleRepository.deleteAllByPostIdInQuery(postIds);
         recruitmentTagRepository.deleteAllByPostIdInQuery(postIds);
         recruitmentCommentRepository.deleteAllByPostIdInQuery(postIds);
@@ -84,5 +83,7 @@ public class UserManagementService {
         userSkillRepository.deleteAllByUserId(userId);
         userLinkRepository.deleteAllByUserId(userId);
         awardRepository.deleteAllByUserId(userId);
+
+        bookmarkRepository.deleteAllByUserId(userId);
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#356 -> dev
- closed #356 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 삭제하려는 유저가 했던 북마크 뿐만 아니라, 삭제하려는 구인글에 대한 북마크도 삭제해야해서 해당 부분 수정했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="569" alt="스크린샷 2024-05-31 오후 2 12 53" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/5762b532-7993-44c8-9f55-2ba96db2bfd7">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
