### PR TITLE
[FIX] 삭제하려는 유저의 신청 이력 삭제 추가

### DIFF
--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantRepository.java
@@ -34,4 +34,9 @@ public interface RecruitmentApplicantRepository extends JpaRepository<Recruitmen
     @Transactional
     @Query("DELETE FROM RecruitmentApplicant r WHERE r.recruitmentPost.id IN :postIds")
     void deleteAllByPostIdInQuery(List<Long> postIds);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM RecruitmentApplicant r WHERE r.applicant.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/UserManagementService.java
@@ -60,6 +60,7 @@ public class UserManagementService {
         deletePortfolios(portfolioIds);
 
         deleteProfile(user.getId());
+        deleteRelatedUserData(user.getId());
 
         userRepository.delete(user);
     }
@@ -83,7 +84,10 @@ public class UserManagementService {
         userSkillRepository.deleteAllByUserId(userId);
         userLinkRepository.deleteAllByUserId(userId);
         awardRepository.deleteAllByUserId(userId);
+    }
 
+    private void deleteRelatedUserData(Long userId){
         bookmarkRepository.deleteAllByUserId(userId);
+        recruitmentApplicantRepository.deleteAllByUserId(userId);
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#356 -> dev
- closed #356

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 삭제하려는 유저의 신청 이력도 삭제해야해서 추가했습니다.
- 구인글 테이블이나, 구인역할 테이블에 있는 신청 수도 삭제하려다가 북마크 횟수랑 비슷한 맥락으로 굳이 삭제 안해도 되겠다고 생각했는데요! 혹시 이 부분에 대해서 문제 생길 것 같은 부분 있다면 말씀주심 감사하겠습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

<img width="662" alt="스크린샷 2024-05-31 오후 3 06 49" src="https://github.com/MeeTeamNumdle/MeeTeam_BackEnd/assets/100754581/1b7a5483-0c57-495d-aef4-c2d025bc9b96">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
