### PR TITLE
[FIX] 이미지 캐싱 오류 해결 및 일부 코드 개선

### DIFF
--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/SimplePortfolioDto.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/dto/SimplePortfolioDto.java
@@ -23,12 +23,15 @@ public class SimplePortfolioDto {
     private boolean isPinned;
     @Schema(description = "핀순서", example = "1")
     private int pinOrder;
+    @Schema(description = "버전", example = "1")
+    private Long version;
 
     @Builder
     @QueryProjection
     public SimplePortfolioDto(Long id, String title, String mainImageUrl, String field, String role,
                               boolean isPinned,
-                              int pinOrder) {
+                              int pinOrder,
+                              Long version) {
         this.id = id;
         this.title = title;
         this.mainImageUrl = mainImageUrl;
@@ -36,5 +39,6 @@ public class SimplePortfolioDto {
         this.role = role;
         this.isPinned = isPinned;
         this.pinOrder = pinOrder;
+        this.version = version;
     }
 }

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
@@ -107,6 +107,9 @@ public class Portfolio extends BaseEntity {
     @ColumnDefault("'ALIVE'")
     private DeleteStatus deleteStatus = DeleteStatus.ALIVE;
 
+    @ColumnDefault("1")
+    private long version = 1;
+
     @Builder
     public Portfolio(Long id, String title, String description, String content, LocalDate proceedStart,
                      LocalDate proceedEnd,

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/entity/Portfolio.java
@@ -145,6 +145,7 @@ public class Portfolio extends BaseEntity {
         this.role = role;
         this.fileOrder = fileOrder;
         this.mainImageFileName = mainImageFileName;
+        version++;
     }
 
     public boolean isAllViewAble(Long userId) {

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/repository/PortfolioCustomRepositoryImpl.java
@@ -68,7 +68,8 @@ public class PortfolioCustomRepositoryImpl implements PortfolioCustomRepository 
                         portfolio.field.name,
                         portfolio.role.name,
                         portfolio.isPin,
-                        portfolio.pinOrder
+                        portfolio.pinOrder,
+                        portfolio.version
                 ))
                 .from(portfolio)
                 .leftJoin(portfolio.role, role)

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioFacade.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioFacade.java
@@ -56,8 +56,8 @@ public class PortfolioFacade {
 
         List<Skill> skills = portfolioSkillService.getPortfolioSkill(portfolio);
         List<PortfolioLink> links = portfolioLinkService.getPortfolioLink(portfolio);
-        String zipFileUrl = cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(user.getEncryptUserId()),
-                portfolio.getZipFileName());
+        String zipFileUrl = cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(writer.getEncryptUserId()),
+                portfolio.getZipFileName(), portfolio.getVersion());
         List<Portfolio> otherPinPortfolios = getUserPortfolio(portfolio);
         return new GetPortfolioResponseDto(
                 portfolio.getTitle(),
@@ -74,8 +74,8 @@ public class PortfolioFacade {
                 links.stream().map(link -> new PortfolioLinkDto(link.getUrl(), link.getDescription())).toList(),
                 otherPinPortfolios.stream().map(otherPortfolio ->
                         portfolioMapper.toGetProfilePortfolioDto(otherPortfolio,
-                                cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(user.getEncryptUserId()),
-                                        otherPortfolio.getMainImageFileName()))).toList(),
+                                cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(writer.getEncryptUserId()),
+                                        otherPortfolio.getMainImageFileName(), otherPortfolio.getVersion()))).toList(),
                 portfolio.isWriter(userId),
                 writer.getNickname()
         );

--- a/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
+++ b/src/main/java/synk/meeteam/domain/portfolio/portfolio/service/PortfolioServiceImpl.java
@@ -81,7 +81,7 @@ public class PortfolioServiceImpl implements PortfolioService {
                 pageable, user);
         userPortfolioDtos.getContent().forEach(userPortfolio -> {
             String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(user.getEncryptUserId()),
-                    userPortfolio.getMainImageUrl());
+                    userPortfolio.getMainImageUrl(), userPortfolio.getVersion());
             userPortfolio.setMainImageUrl(imageUrl);
         });
         SliceInfo pageInfo = new SliceInfo(page, size, userPortfolioDtos.hasNext());
@@ -95,7 +95,7 @@ public class PortfolioServiceImpl implements PortfolioService {
                 PageRequest.of(page - 1, size), user);
         myPortfolios.getContent().forEach(myPortfolio -> {
             String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.getPortfolioPath(user.getEncryptUserId()),
-                    myPortfolio.getMainImageUrl());
+                    myPortfolio.getMainImageUrl(), myPortfolio.getVersion());
             myPortfolio.setMainImageUrl(imageUrl);
         });
         PageInfo pageInfo = new PageInfo(page, size, myPortfolios.getTotalElements(), myPortfolios.getTotalPages());

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantDto.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/dto/response/GetApplicantDto.java
@@ -32,12 +32,14 @@ public class GetApplicantDto {
     String applyRoleName;
     @Schema(description = "전하는 말", example = "저 관심있어용")
     String message;
+    @Schema(description = "버전", example = "1")
+    Long version;
 
     @QueryProjection
     public GetApplicantDto(Long applicantId, String userId, String nickname, String profileImg, String name,
-                           double score, String universityName, String departmentName, String email,
-                           int year,
-                           String applyRoleName, String message) {
+                           double score,
+                           String universityName, String departmentName, String email, int year, String applyRoleName,
+                           String message, Long version) {
         this.applicantId = applicantId;
         this.userId = userId;
         this.nickname = nickname;
@@ -50,6 +52,7 @@ public class GetApplicantDto {
         this.year = year;
         this.applyRoleName = applyRoleName;
         this.message = message;
+        this.version = version;
     }
 
     public void setEncryptedUserIdAndProfileImg(String userId, String profileImg) {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/repository/RecruitmentApplicantCustomRepositoryImpl.java
@@ -54,7 +54,8 @@ public class RecruitmentApplicantCustomRepositoryImpl implements RecruitmentAppl
                         recruitmentApplicant.applicant.name, recruitmentApplicant.applicant.gpa,
                         recruitmentApplicant.applicant.university.name, recruitmentApplicant.applicant.department.name,
                         getMainMail, recruitmentApplicant.applicant.admissionYear,
-                        recruitmentApplicant.role.name, recruitmentApplicant.comment))
+                        recruitmentApplicant.role.name, recruitmentApplicant.comment,
+                        recruitmentApplicant.applicant.imgVersion))
                 .from(recruitmentApplicant)
                 .leftJoin(recruitmentApplicant.applicant, user)
                 .leftJoin(recruitmentApplicant.recruitmentPost, recruitmentPost)

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_applicant/service/RecruitmentApplicantService.java
@@ -108,7 +108,7 @@ public class RecruitmentApplicantService {
                 roleId, pageable);
         applicantDtos.stream().forEach(applicant -> applicant.setEncryptedUserIdAndProfileImg(
                 Encryption.encryptLong(Long.parseLong(applicant.getUserId())),
-                cloudFrontService.getSignedUrl(USER, applicant.getProfileImg())));
+                cloudFrontService.getSignedUrl(USER, applicant.getProfileImg(), applicant.getVersion())));
 
         SliceInfo pageInfo = new SliceInfo(page, size, applicantDtos.hasNext());
         return new GetApplicantResponseDto(applicantDtos.getContent(), pageInfo);

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepositoryCustomImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/repository/RecruitmentCommentRepositoryCustomImpl.java
@@ -22,7 +22,7 @@ public class RecruitmentCommentRepositoryCustomImpl implements RecruitmentCommen
                         user.nickname,
                         user.profileImgFileName, recruitmentComment.content, recruitmentComment.createdAt,
                         recruitmentComment.isParent, recruitmentComment.groupNumber, recruitmentComment.groupOrder,
-                        recruitmentComment.isDeleted))
+                        recruitmentComment.isDeleted, user.imgVersion))
                 .from(recruitmentComment)
                 .leftJoin(user)
                 .on(recruitmentComment.createdBy.eq(user.id))

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/RecruitmentCommentService.java
@@ -36,7 +36,8 @@ public class RecruitmentCommentService {
 
         for (RecruitmentCommentVO comment : commentVOs) {
             boolean isWriter = writerId.equals(comment.getUserId());
-            String profileImg = cloudFrontService.getSignedUrl(S3FilePath.USER, comment.getProfileImg());
+            String profileImg = cloudFrontService.getSignedUrl(S3FilePath.USER, comment.getProfileImg(),
+                    comment.getUserVersion());
             String commentWriterId = Encryption.encryptLong(comment.getUserId());
 
             if (comment.isParent()) {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/vo/RecruitmentCommentVO.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_comment/service/vo/RecruitmentCommentVO.java
@@ -17,12 +17,14 @@ public class RecruitmentCommentVO {
     long groupNumber;
     long groupOrder;
     boolean isDeleted;
+    Long userVersion;
 
     @Builder
     @QueryProjection
     public RecruitmentCommentVO(Long id, Long userId, String nickname, String profileImg, String content,
                                 LocalDateTime createAt,
-                                boolean isParent, long groupNumber, long groupOrder, boolean isDeleted) {
+                                boolean isParent, long groupNumber, long groupOrder, boolean isDeleted,
+                                Long userVersion) {
         this.id = id;
         this.userId = userId;
         this.nickname = nickname;
@@ -33,6 +35,7 @@ public class RecruitmentCommentVO {
         this.groupNumber = groupNumber;
         this.groupOrder = groupOrder;
         this.isDeleted = isDeleted;
+        this.userVersion = userVersion;
     }
 
     public Long getUserId() {

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/api/RecruitmentPostController.java
@@ -133,7 +133,8 @@ public class RecruitmentPostController implements RecruitmentPostApi {
         }
 
         User writer = userService.findById(recruitmentPost.getCreatedBy());
-        String writerImgUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, writer.getProfileImgFileName());
+        String writerImgUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, writer.getProfileImgFileName(),
+                writer.getImgVersion());
 
         List<RecruitmentRole> recruitmentRoles = recruitmentRoleService.findByRecruitmentPostId(postId);
 

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentManagementRepositoryImpl.java
@@ -54,7 +54,8 @@ public class RecruitmentManagementRepositoryImpl implements RecruitmentManagemen
                                 manageType == ManageType.BOOKMARKED ? Expressions.asBoolean(true)
                                         : RecruitmentExpressionUtils.isBookmark(userDomain),
                                 recruitmentPost.createdAt,
-                                recruitmentPost.isClosed
+                                recruitmentPost.isClosed,
+                                writer.imgVersion
                         )
                 )
                 .distinct()

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/RecruitmentPostSearchRepositoryImpl.java
@@ -65,7 +65,8 @@ public class RecruitmentPostSearchRepositoryImpl implements RecruitmentPostSearc
                                 recruitmentPost.deadline,
                                 isBookmark(userDomain),
                                 recruitmentPost.createdAt,
-                                recruitmentPost.isClosed
+                                recruitmentPost.isClosed,
+                                writer.imgVersion
                         )
                 )
                 .distinct()

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/vo/RecruitmentPostVo.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/repository/vo/RecruitmentPostVo.java
@@ -21,13 +21,15 @@ public class RecruitmentPostVo {
     private Boolean isBookmarked;
     private LocalDateTime createdAt;
     private Boolean isClosed;
+    private Long writerVersion;
 
     @Builder
     @QueryProjection
     public RecruitmentPostVo(Long id, String title, Category category, Scope scope, Long writerId,
                              String writerNickname,
                              String writerProfileImg, LocalDate deadline, Boolean isBookmarked, LocalDateTime createdAt,
-                             Boolean isClosed) {
+                             Boolean isClosed,
+                             Long writerVersion) {
         this.id = id;
         this.title = title;
         this.category = category;
@@ -39,5 +41,6 @@ public class RecruitmentPostVo {
         this.isBookmarked = isBookmarked;
         this.createdAt = createdAt;
         this.isClosed = isClosed;
+        this.writerVersion = writerVersion;
     }
 }

--- a/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
+++ b/src/main/java/synk/meeteam/domain/recruitment/recruitment_post/service/RecruitmentPostService.java
@@ -106,7 +106,8 @@ public class RecruitmentPostService {
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
                 .map((postVo) -> {
                     String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
-                    String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, postVo.getWriterProfileImg());
+                    String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, postVo.getWriterProfileImg(),
+                            postVo.getWriterVersion());
                     return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
                 }).toList();
 
@@ -138,7 +139,8 @@ public class RecruitmentPostService {
         List<SimpleRecruitmentPostDto> contents = postVos.stream()
                 .map((postVo) -> {
                     String writerEncryptedId = Encryption.encryptLong(postVo.getWriterId());
-                    String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, postVo.getWriterProfileImg());
+                    String imageUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, postVo.getWriterProfileImg(),
+                            postVo.getWriterVersion());
                     return simpleRecruitmentPostMapper.toSimpleRecruitmentPostDto(postVo, writerEncryptedId, imageUrl);
                 }).toList();
         return new PaginationDto<>(contents, pageInfo);

--- a/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
+++ b/src/main/java/synk/meeteam/domain/user/user/api/UserController.java
@@ -82,7 +82,7 @@ public class UserController implements UserApi {
     @Override
     @GetMapping("/profile/image")
     public ResponseEntity<GetProfileImageResponseDto> getProfileImage(@AuthUser User user) {
-        String profileImgUrl = cloudFrontService.getSignedUrl(USER, user.getProfileImgFileName());
+        String profileImgUrl = cloudFrontService.getSignedUrl(USER, user.getProfileImgFileName(), user.getImgVersion());
         return ResponseEntity.ok(GetProfileImageResponseDto.of(profileImgUrl));
     }
 

--- a/src/main/java/synk/meeteam/domain/user/user/entity/User.java
+++ b/src/main/java/synk/meeteam/domain/user/user/entity/User.java
@@ -163,6 +163,9 @@ public class User extends BaseTimeEntity {
     @ColumnDefault("1")
     private boolean isFirstApplicantAccess = true;
 
+    @ColumnDefault("1")
+    private long imgVersion = 1;
+
     public User(String platformId) {
         this.platformId = platformId;
     }
@@ -220,6 +223,7 @@ public class User extends BaseTimeEntity {
         this.gpa = gpa;
         this.maxGpa = maxGpa;
         this.interestRole = role;
+        this.imgVersion++;
 
         if (subEmail == null && !isUniversityMainEmail) {
             this.isUniversityMainEmail = true;
@@ -302,7 +306,7 @@ public class User extends BaseTimeEntity {
         this.isFirstApplicantAccess = false;
     }
 
-    public String getMainEmail(){
+    public String getMainEmail() {
         return isUniversityMainEmail ? universityEmail : subEmail;
     }
 }

--- a/src/main/java/synk/meeteam/domain/user/user/service/ProfileFacade.java
+++ b/src/main/java/synk/meeteam/domain/user/user/service/ProfileFacade.java
@@ -71,7 +71,8 @@ public class ProfileFacade {
     public GetProfileResponseDto readProfile(User user, String encryptedId) {
         Long userId = Encryption.decryptLong(encryptedId);
         ProfileDto openProfile = userService.getOpenProfile(userId, user);
-        String profileImgUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, openProfile.profileImgFileName());
+        String profileImgUrl = cloudFrontService.getSignedUrl(S3FilePath.USER, openProfile.profileImgFileName(),
+                user.getImgVersion());
         List<GetProfileUserLinkDto> links = getProfileLinks(userId);
         List<GetProfileAwardDto> awards = getProfileAwards(userId);
         List<SimplePortfolioDto> portfolios = getProfilePortfolios(userId, encryptedId);
@@ -96,7 +97,7 @@ public class ProfileFacade {
         return portfolios.stream().map((portfolio) -> {
             String imageUrl = cloudFrontService.getSignedUrl(
                     S3FilePath.getPortfolioPath(encryptedId),
-                    portfolio.getMainImageFileName());
+                    portfolio.getMainImageFileName(), portfolio.getVersion());
             return portfolioMapper.toGetProfilePortfolioDto(portfolio, imageUrl);
         }).toList();
     }

--- a/src/main/java/synk/meeteam/global/api/ServerProfileController.java
+++ b/src/main/java/synk/meeteam/global/api/ServerProfileController.java
@@ -26,7 +26,8 @@ public class ServerProfileController {
                                                     @RequestParam(name = "file-name") String fileName) {
         String extension = StringUtils.getFilenameExtension(fileName);
 
-        return ResponseEntity.ok().body(cloudFrontService.getProfileSignedUrl(extension, user.getId()));
+        return ResponseEntity.ok()
+                .body(cloudFrontService.getProfileSignedUrl(extension, user.getId(), user.getImgVersion()));
     }
 
     @GetMapping("/portfolio/signed-url")
@@ -35,11 +36,7 @@ public class ServerProfileController {
                                                           @RequestParam(name = "portfolio", required = false) Long portfolioId
     ) {
         String thumbnailExtension = StringUtils.getFilenameExtension(fileName);
-        Portfolio portfolio = null;
-
-        if (portfolioId != null) {
-            portfolio = portfolioService.getPortfolio(portfolioId);
-        }
+        Portfolio portfolio = portfolioId != null ? portfolioService.getPortfolio(portfolioId) : null;
 
         return ResponseEntity.ok().body(
                 cloudFrontService.getPortfolioSignedUrl(thumbnailExtension, portfolio, user.getId())

--- a/src/main/java/synk/meeteam/infra/aws/strategy/NoPortfolioStrategy.java
+++ b/src/main/java/synk/meeteam/infra/aws/strategy/NoPortfolioStrategy.java
@@ -1,0 +1,32 @@
+package synk.meeteam.infra.aws.strategy;
+
+import static synk.meeteam.infra.aws.S3FilePath.getFileFullName;
+import static synk.meeteam.infra.aws.S3FilePath.getZipFileFullName;
+
+import java.util.UUID;
+
+public class NoPortfolioStrategy implements PortfolioStrategy {
+
+    private String fileName;
+    private String zipFileName;
+
+    public NoPortfolioStrategy() {
+        this.fileName = UUID.randomUUID().toString();
+        this.zipFileName = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getZipFileName() {
+        return getZipFileFullName(fileName);
+    }
+
+    @Override
+    public String getThumbnailFileName(String thumbnailExtension) {
+        return getFileFullName(zipFileName, thumbnailExtension);
+    }
+
+    @Override
+    public long getVersion() {
+        return 1;
+    }
+}

--- a/src/main/java/synk/meeteam/infra/aws/strategy/PortfolioExistStrategy.java
+++ b/src/main/java/synk/meeteam/infra/aws/strategy/PortfolioExistStrategy.java
@@ -1,0 +1,30 @@
+package synk.meeteam.infra.aws.strategy;
+
+import static synk.meeteam.infra.aws.S3FilePath.getFileFullName;
+
+import org.springframework.util.StringUtils;
+import synk.meeteam.domain.portfolio.portfolio.entity.Portfolio;
+
+public class PortfolioExistStrategy implements PortfolioStrategy {
+    private final Portfolio portfolio;
+
+    public PortfolioExistStrategy(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+
+    @Override
+    public String getZipFileName() {
+        return portfolio.getZipFileName();
+    }
+
+    @Override
+    public String getThumbnailFileName(String thumbnailExtension) {
+        return getFileFullName(StringUtils.stripFilenameExtension(portfolio.getMainImageFileName()),
+                thumbnailExtension);
+    }
+
+    @Override
+    public long getVersion() {
+        return portfolio.getVersion();
+    }
+}

--- a/src/main/java/synk/meeteam/infra/aws/strategy/PortfolioStrategy.java
+++ b/src/main/java/synk/meeteam/infra/aws/strategy/PortfolioStrategy.java
@@ -1,0 +1,9 @@
+package synk.meeteam.infra.aws.strategy;
+
+public interface PortfolioStrategy {
+    String getZipFileName();
+
+    String getThumbnailFileName(String thumbnailExtension);
+
+    long getVersion();
+}

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioFixture.java
@@ -50,8 +50,8 @@ public class PortfolioFixture {
     public static Slice<SimplePortfolioDto> createSlicePortfolioDtos() {
         return new SliceImpl<>(
                 List.of(
-                        new SimplePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1),
-                        new SimplePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2)
+                        new SimplePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1, 1L),
+                        new SimplePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2, 1L)
                 ),
                 PageRequest.of(1, 12),
                 false
@@ -61,8 +61,8 @@ public class PortfolioFixture {
     public static GetUserPortfolioResponseDto createUserAllPortfolios() {
         return new GetUserPortfolioResponseDto(
                 List.of(
-                        new SimplePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1),
-                        new SimplePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2)
+                        new SimplePortfolioDto(1L, "타이틀1", "이미지url", "개발", "개발자", true, 1, 1L),
+                        new SimplePortfolioDto(2L, "타이틀2", "이미지url", "개발", "개발자", true, 2, 1L)
                 ),
                 new SliceInfo(1, 12, false)
         );

--- a/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/portfolio/portfolio/PortfolioServiceTest.java
@@ -115,7 +115,7 @@ public class PortfolioServiceTest {
         //given
         doReturn(PortfolioFixture.createSlicePortfolioDtos()).when(portfolioRepository)
                 .findSlicePortfoliosByUserOrderByCreatedAtDesc(eq(PageRequest.of(0, 12)), any());
-        doReturn("url입니다.").when(cloudFrontService).getSignedUrl(any(), any());
+        doReturn("url입니다.").when(cloudFrontService).getSignedUrl(any(), any(), any());
         //when
         GetUserPortfolioResponseDto userAllPortfolios = portfolioService.getSliceMyAllPortfolio(1, 12,
                 User.builder().build());

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_applicant/RecruitmentApplicantServiceTest.java
@@ -434,10 +434,10 @@ public class RecruitmentApplicantServiceTest {
 
         GetApplicantDto dto1 = new GetApplicantDto(1L, "1", "닉네임입니다1",
                 "이미지입니다1", "이름입니다1", 4.3, "광운대학교", "소프트웨어학부", "qwer123@naver.com", 2018,
-                "백엔드개발자", "전하는 말입니다1");
+                "백엔드개발자", "전하는 말입니다1", 1L);
         GetApplicantDto dto2 = new GetApplicantDto(2L, "2", "닉네임입니다2",
                 "이미지입니다2", "이름입니다2", 4.2, "광운대학교", "소프트웨어학부", "qwer456@naver.com", 2018,
-                "백엔드개발자", "전하는 말입니다2");
+                "백엔드개발자", "전하는 말입니다2", 1L);
 
         doReturn(new SliceImpl<>(
                 List.of(dto1, dto2),
@@ -445,7 +445,7 @@ public class RecruitmentApplicantServiceTest {
                 false
         )).when(recruitmentApplicantRepository).findByPostIdAndRoleId(any(), any(), any());
 
-        doReturn("이미지입니다").when(cloudFrontService).getSignedUrl(any(), any());
+        doReturn("이미지입니다").when(cloudFrontService).getSignedUrl(any(), any(), any());
 
         try (MockedStatic<Encryption> utilities = Mockito.mockStatic(Encryption.class)) {
             utilities.when(() -> Encryption.encryptLong(any())).thenReturn("1234");

--- a/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
+++ b/src/test/java/synk/meeteam/domain/recruitment/recruitment_comment/RecruitmentCommentServiceTest.java
@@ -50,7 +50,7 @@ public class RecruitmentCommentServiceTest {
         doReturn(recruitmentComments).when(recruitmentCommentRepository)
                 .findAllByRecruitmentId(recruitmentPost.getId());
 
-        doReturn("임시 url").when(cloudFrontService).getSignedUrl(any(), any());
+        doReturn("임시 url").when(cloudFrontService).getSignedUrl(any(), any(), any());
 
         // when
         List<GetCommentResponseDto> getCommentResponseDtos = recruitmentCommentService.getRecruitmentComments(

--- a/src/test/java/synk/meeteam/domain/user/user/UserFixture.java
+++ b/src/test/java/synk/meeteam/domain/user/user/UserFixture.java
@@ -82,7 +82,7 @@ public class UserFixture {
                 4.3,
                 2019,
                 List.of(
-                        new SimplePortfolioDto(1L, "Meeteam 팀을 만나다", "https://~", "개발", "백엔드개발자", true, 1)
+                        new SimplePortfolioDto(1L, "Meeteam 팀을 만나다", "https://~", "개발", "백엔드개발자", true, 1, 1L)
                 ),
                 List.of(
                         new GetProfileUserLinkDto("https://~~", "Link"),


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [X] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#390 -> dev
- closed #390

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 문자열 쿼리 기반으로 파일의 버전을 관리하도록 변경하였습니다.
- 이에 따라 일부 스키마 변경이 이루어졌습니다.
   - `user`에  `imgVersion` 추가
   - `portfolio`에 `version` 추가
- 일부 로직에서 dto에 version 관련 데이터가 추가되었습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 현재 진행한 방식의 경우, 기능 구현을 위한 코드로 되어있습니다.
- 이미지에 대한 버전을 dto로 조회해와서 그대로 서빙하기 때문에 이상하다고 느껴지긴합니다.
- 때문에 내부에서 version을 제외한 dto로 한번 더 변환하면 어떨까 싶은데 어떻게 생각하시나요?